### PR TITLE
feat: add CMake find_package() export for OSIUtilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,15 @@ if (NOT OSIUTILITIES_DOCS_ONLY)
                 "Run: git submodule update --init --recursive")
     endif ()
     message(STATUS "Using bundled osi-cpp submodule at ${OSI_CPP_DIR}")
-    add_subdirectory(${OSI_CPP_DIR} ${CMAKE_BINARY_DIR}/osi-cpp EXCLUDE_FROM_ALL)
+    add_subdirectory(${OSI_CPP_DIR} ${CMAKE_BINARY_DIR}/osi-cpp)
+
+    # osi-cpp's shared library target does not declare dllexport symbols, so on
+    # Windows MSVC no import library (.lib) is generated.  Setting this property
+    # makes CMake auto-export every symbol so the import lib is always produced.
+    if(WIN32 AND TARGET open_simulation_interface)
+        set_target_properties(open_simulation_interface PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    endif()
+
     get_directory_property(OSI_VERSION_MAJOR DIRECTORY ${OSI_CPP_DIR} DEFINITION VERSION_MAJOR)
     get_directory_property(OSI_VERSION_MINOR DIRECTORY ${OSI_CPP_DIR} DEFINITION VERSION_MINOR)
     get_directory_property(OSI_VERSION_PATCH DIRECTORY ${OSI_CPP_DIR} DEFINITION VERSION_PATCH)

--- a/cpp/cmake/FindCompression.cmake
+++ b/cpp/cmake/FindCompression.cmake
@@ -41,16 +41,18 @@ function(find_compression_libraries)
 
     # Fallback to pkg-config if CONFIG mode didn't find targets
     if (NOT LZ4_TARGET_LOCAL OR NOT ZSTD_TARGET_LOCAL)
-        find_package(PkgConfig REQUIRED)
-        
-        if (NOT LZ4_TARGET_LOCAL)
-            pkg_check_modules(lz4 REQUIRED IMPORTED_TARGET liblz4)
-            set(LZ4_TARGET_LOCAL PkgConfig::lz4)
-        endif ()
-        
-        if (NOT ZSTD_TARGET_LOCAL)
-            pkg_check_modules(zstd REQUIRED IMPORTED_TARGET libzstd)
-            set(ZSTD_TARGET_LOCAL PkgConfig::zstd)
+        find_package(PkgConfig QUIET)
+
+        if (PkgConfig_FOUND)
+            if (NOT LZ4_TARGET_LOCAL)
+                pkg_check_modules(lz4 REQUIRED IMPORTED_TARGET liblz4)
+                set(LZ4_TARGET_LOCAL PkgConfig::lz4)
+            endif ()
+
+            if (NOT ZSTD_TARGET_LOCAL)
+                pkg_check_modules(zstd REQUIRED IMPORTED_TARGET libzstd)
+                set(ZSTD_TARGET_LOCAL PkgConfig::zstd)
+            endif ()
         endif ()
     endif ()
 

--- a/cpp/cmake/OSIUtilitiesConfig.cmake.in
+++ b/cpp/cmake/OSIUtilitiesConfig.cmake.in
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# SPDX-License-Identifier: MPL-2.0
+#
+# OSIUtilitiesConfig.cmake.in — Package configuration for find_package(OSIUtilities)
+#
+# Provides the following imported targets:
+#   OSIUtilities::OSIUtilities — The OSI utilities library (tracefile readers/writers)
+#
+# Transitive dependencies (automatically available via the target):
+#   - open_simulation_interface (OSI C++ bindings + protobuf)
+#   - MCAP headers
+#   - LZ4 and ZSTD compression libraries
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Find OSI (provides open_simulation_interface::* targets and transitively protobuf).
+# osi-cpp installs its cmake config to:
+#   - CMake/open_simulation_interface-<major>/  on Windows
+#   - lib/cmake/open_simulation_interface-<major>/  on Unix
+# The Windows path is non-standard, so we add both the install prefix and its CMake/
+# subdirectory to CMAKE_PREFIX_PATH to ensure find_package can locate it.
+list(APPEND CMAKE_PREFIX_PATH "${PACKAGE_PREFIX_DIR}" "${PACKAGE_PREFIX_DIR}/CMake")
+find_dependency(open_simulation_interface)
+
+# Find compression libraries needed by MCAP support.
+# Ship our FindCompression module alongside the config so consumers can locate lz4/zstd
+# the same way we do.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+include(FindCompression)
+find_compression_libraries()
+if (NOT COMPRESSION_FOUND)
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+        "OSIUtilities requires LZ4 and ZSTD compression libraries")
+    return()
+endif ()
+
+# Include the exported targets
+include("${CMAKE_CURRENT_LIST_DIR}/OSIUtilitiesTargets.cmake")
+
+check_required_components(OSIUtilities)

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Add subdirectories for organized modules
 include_directories(tracefile)
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 # specify library source files
 set(OSIUtilities_SRCS
@@ -20,12 +21,14 @@ set(OSIUtilities_SRCS
 
 # Create a library target for the entire library
 add_library(OSIUtilities ${OSIUtilities_SRCS})
+add_library(OSIUtilities::OSIUtilities ALIAS OSIUtilities)
 
 target_compile_features(OSIUtilities PUBLIC cxx_std_17)
 set_target_properties(OSIUtilities PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
+    EXPORT_NAME OSIUtilities
 )
 
 # add a compile definition to specify the version of the trace file specification.
@@ -49,12 +52,16 @@ if (WIN32)
 endif ()
 
 
-# Link against OSI made available by parent CMakeLists.txt
+# Link against OSI made available by parent CMakeLists.txt.
+# PUBLIC because the public API exposes protobuf types (google::protobuf::Message
+# in ReadResult, google::protobuf::Descriptor* in AddChannel) and consumers need
+# OSI headers to instantiate WriteMessage<osi3::GroundTruth>() etc.
 if (LINK_WITH_SHARED_OSI)
-    target_link_libraries(OSIUtilities PRIVATE open_simulation_interface::open_simulation_interface)
+    set(OSI_LINK_TARGET open_simulation_interface::open_simulation_interface)
 else ()
-    target_link_libraries(OSIUtilities PRIVATE open_simulation_interface::open_simulation_interface_pic)
+    set(OSI_LINK_TARGET open_simulation_interface::open_simulation_interface_pic)
 endif ()
+target_link_libraries(OSIUtilities PUBLIC ${OSI_LINK_TARGET})
 
 
 # get mcap and its dependencies
@@ -62,6 +69,7 @@ set(MCAP_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../submodules/mcap/cpp/mcap/
 target_include_directories(OSIUtilities
     PUBLIC
         $<BUILD_INTERFACE:${MCAP_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # Find compression libraries (LZ4, ZSTD)
@@ -69,16 +77,57 @@ include(FindCompression)
 find_compression_libraries()
 
 if (COMPRESSION_FOUND)
+    # PRIVATE: lz4/zstd are not exposed in any public header — they are used
+    # internally by the MCAP implementation compiled into OSIUtilities.
+    # CMake still propagates them in the link line for static library consumers.
     target_link_libraries(OSIUtilities PRIVATE ${LZ4_TARGET} ${ZSTD_TARGET})
 else ()
     message(FATAL_ERROR "Could not find LZ4 and ZSTD compression libraries")
 endif ()
 
+# --- Install rules ---
+
 install(TARGETS OSIUtilities
+    EXPORT OSIUtilitiesTargets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/cpp/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY ${MCAP_INCLUDE_DIR}/mcap DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# --- Export targets for find_package() ---
+
+install(EXPORT OSIUtilitiesTargets
+    NAMESPACE OSIUtilities::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/OSIUtilities
+)
+
+# Generate and install package config file
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/cpp/cmake/OSIUtilitiesConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/OSIUtilitiesConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/OSIUtilities
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/OSIUtilitiesConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/OSIUtilitiesConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/OSIUtilitiesConfigVersion.cmake"
+    # Install FindCompression so consumers can find lz4/zstd
+    "${PROJECT_SOURCE_DIR}/cpp/cmake/FindCompression.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/OSIUtilities
+)
+
+# Export from build tree for development without install
+export(EXPORT OSIUtilitiesTargets
+    NAMESPACE OSIUtilities::
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/OSIUtilitiesTargets.cmake"
+)

--- a/doc/building.md
+++ b/doc/building.md
@@ -481,5 +481,6 @@ git submodule update --init --recursive
 
 ## Next Steps
 
+- [Integration Guide](integration.md) - Use OSIUtilities in your downstream project
 - [Development Setup](development.md) - Configure your development environment
 - [Examples](examples.md) - Learn how to use the library

--- a/doc/guides/index.rst
+++ b/doc/guides/index.rst
@@ -8,6 +8,7 @@ Guides
    :maxdepth: 2
 
    ../building
+   ../integration
    ../setup
    ../development
    ../contributing

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -1,0 +1,367 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+SPDX-License-Identifier: MPL-2.0
+-->
+
+# Integrating OSIUtilities into Your Project
+
+This guide covers how to use the OSIUtilities C++ library in a downstream CMake
+project. Three integration methods are available — choose based on your
+dependency management strategy and caching requirements.
+
+## Quick Start
+
+After installation (any method), usage in CMake is always the same:
+
+```cmake
+find_package(OSIUtilities REQUIRED)
+target_link_libraries(my_target PRIVATE OSIUtilities::OSIUtilities)
+```
+
+This gives you:
+
+- The OSIUtilities library (MCAP/binary/TXTH trace file readers and writers)
+- OSI C++ bindings (osi3 protobuf headers and libraries, transitively)
+- Protobuf (transitively, via OSI)
+- MCAP headers (transitively)
+- LZ4 and ZSTD compression (linked internally, headers not exposed)
+
+## Integration Methods Overview
+
+| Method | Dependency control | Caching | Complexity | Best for |
+| --- | --- | --- | --- | --- |
+| **A. Two-phase build** | Baseline (vcpkg) or custom | ✅ Excellent | Medium | CI pipelines, large projects |
+| **B. add_subdirectory** | Full (your project controls) | Via ccache | Low | Embedded/submodule workflows |
+| **C. System install** | Full (system packages) | OS package cache | Low | Linux distro packaging |
+
+---
+
+## Method A: Two-Phase Build with `find_package()` (Recommended)
+
+Build and install OSIUtilities and its dependencies in a separate phase, then
+consume via `find_package()`. This gives **excellent CI caching** — the
+dependency install directory can be cached and only rebuilt when the submodule
+is bumped.
+
+### Step 1: Add as a submodule
+
+```bash
+git submodule add https://github.com/lichtblick-suite/asam-osi-utilities.git \
+    externals/asam-osi-utilities
+git submodule update --init --recursive
+```
+
+### Step 2: Phase A — Build and install dependencies
+
+```bash
+# Configure (uses vcpkg for protobuf, lz4, zstd)
+cmake -S externals/asam-osi-utilities \
+      -B build-deps \
+      --preset vcpkg \
+      -DBUILD_EXAMPLES=OFF \
+      -DBUILD_TESTING=OFF
+
+# Build
+cmake --build build-deps --config Release --parallel
+
+# Install to a local prefix
+cmake --install build-deps --config Release --prefix deps/
+```
+
+This produces a self-contained `deps/` directory with all headers, libraries,
+and CMake config files.
+
+### Step 3: Phase B — Build your project
+
+```cmake
+# Your project's CMakeLists.txt
+cmake_minimum_required(VERSION 3.16)
+project(my_project)
+
+find_package(OSIUtilities REQUIRED)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app PRIVATE OSIUtilities::OSIUtilities)
+```
+
+Configure with the install prefix and vcpkg dependencies:
+
+```bash
+cmake -S . -B build \
+      -DCMAKE_PREFIX_PATH=deps/ \
+      -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+      -DVCPKG_INSTALLED_DIR=build-deps/vcpkg_installed \
+      -DVCPKG_MANIFEST_MODE=OFF
+
+cmake --build build --config Release
+```
+
+**Key flags explained:**
+
+| Flag | Purpose |
+| --- | --- |
+| `CMAKE_PREFIX_PATH=deps/` | Tells CMake where to find OSIUtilities and OSI configs |
+| `CMAKE_TOOLCHAIN_FILE` | vcpkg toolchain ensures protobuf is found in CONFIG mode (required for abseil transitive deps) |
+| `VCPKG_INSTALLED_DIR` | Points to Phase A's vcpkg-installed packages (protobuf, lz4, zstd) |
+| `VCPKG_MANIFEST_MODE=OFF` | Prevents vcpkg from trying to install packages again — uses existing ones |
+
+### CI Caching
+
+Cache the `deps/` directory and `build-deps/vcpkg_installed/` keyed on the
+submodule commit hash:
+
+```yaml
+# GitHub Actions example
+- uses: actions/cache@v4
+  with:
+    path: |
+      deps/
+      build-deps/vcpkg_installed/
+    key: osi-utils-${{ hashFiles('externals/asam-osi-utilities/**') }}
+```
+
+Phase A only re-runs when the submodule is bumped. Phase B (your project) uses
+the cached artifacts and builds in seconds.
+
+---
+
+## Method B: `add_subdirectory()` (Simplest)
+
+Embed asam-osi-utilities directly in your CMake build tree. This is the
+simplest approach and gives your project full control over all dependencies.
+
+### Step 1: Add as a submodule
+
+```bash
+git submodule add https://github.com/lichtblick-suite/asam-osi-utilities.git \
+    externals/asam-osi-utilities
+git submodule update --init --recursive
+```
+
+### Step 2: Include in your CMakeLists.txt
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(my_project)
+
+# Provide protobuf, lz4, zstd before adding the subdirectory.
+# Option 1: vcpkg toolchain (recommended)
+# Option 2: find_package(Protobuf), find_package(lz4), find_package(zstd)
+# Option 3: System packages (Linux)
+
+# Disable parts you don't need
+set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+
+add_subdirectory(externals/asam-osi-utilities)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app PRIVATE OSIUtilities::OSIUtilities)
+```
+
+### Dependency resolution
+
+With `add_subdirectory()`, **your project** is responsible for making protobuf,
+lz4, and zstd available. Common approaches:
+
+**vcpkg (cross-platform):** Add a `vcpkg.json` to your project:
+
+```json
+{
+  "dependencies": ["protobuf", "lz4", "zstd"]
+}
+```
+
+Then configure with `CMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake`.
+
+**System packages (Linux):**
+
+```bash
+# Debian/Ubuntu
+sudo apt install libprotobuf-dev protobuf-compiler liblz4-dev libzstd-dev
+
+# Fedora/RHEL
+sudo dnf install protobuf-devel lz4-devel libzstd-devel
+```
+
+Then configure with the `base` preset or plain `cmake`.
+
+### Trade-offs
+
+- ✅ Simplest setup — no install step, targets available directly
+- ✅ Full control over dependency versions (your CMake environment provides them)
+- ❌ No caching benefit — asam-osi-utilities recompiles with every clean build
+- ❌ OSI protobuf code generation runs every build (can be slow)
+
+---
+
+## Method C: System Install + `find_package()`
+
+Install asam-osi-utilities system-wide or to a custom prefix, then consume via
+`find_package()` in any project. Useful for Linux distro packaging or shared
+development environments.
+
+### Step 1: Build and install
+
+```bash
+git clone --recurse-submodules \
+    https://github.com/lichtblick-suite/asam-osi-utilities.git
+cd asam-osi-utilities
+
+# Using system packages (no vcpkg)
+cmake --preset base \
+      -DBUILD_EXAMPLES=OFF \
+      -DBUILD_TESTING=OFF
+cmake --build build --config Release --parallel
+sudo cmake --install build --config Release
+```
+
+This installs to `/usr/local/` by default. Override with `--prefix`:
+
+```bash
+cmake --install build --config Release --prefix /opt/osi-utilities
+```
+
+### Step 2: Use in your project
+
+```cmake
+find_package(OSIUtilities REQUIRED)
+target_link_libraries(my_app PRIVATE OSIUtilities::OSIUtilities)
+```
+
+If installed to a non-standard prefix:
+
+```bash
+cmake -S . -B build -DCMAKE_PREFIX_PATH=/opt/osi-utilities
+```
+
+---
+
+## Customizing Dependencies
+
+### Using a different protobuf version
+
+Protobuf is a **public dependency** — `google::protobuf::Message` appears in
+the OSIUtilities API. The consumer and OSIUtilities **must use the same
+protobuf version** (ABI-compatible) to avoid ODR violations.
+
+**With two-phase build (Method A):** The protobuf version is determined by the
+vcpkg baseline in `vcpkg-configuration.json`. To override:
+
+```bash
+# Option 1: Use the base preset with your own protobuf
+cmake -S externals/asam-osi-utilities -B build-deps \
+      --preset base \
+      -DProtobuf_DIR=/path/to/your/protobuf/lib/cmake/protobuf
+
+# Option 2: Override vcpkg baseline
+# Create your own vcpkg-configuration.json with a different baseline hash
+# and pass it via VCPKG_MANIFEST_DIR
+cmake -S externals/asam-osi-utilities -B build-deps \
+      --preset vcpkg \
+      -DVCPKG_MANIFEST_DIR=/path/to/your/vcpkg-manifest/
+```
+
+**With add_subdirectory (Method B):** Your project provides protobuf. If you
+call `find_package(Protobuf)` before `add_subdirectory(asam-osi-utilities)`,
+your protobuf is used automatically (CMake's `find_package` is a no-op when
+the package is already found).
+
+### Controlling compression libraries (lz4, zstd)
+
+LZ4 and ZSTD are **private dependencies** — they are not exposed in any public
+header. Consumers do not need their headers, but the libraries must be
+available at link time (CMake handles this automatically for both static and
+shared builds).
+
+To use custom lz4/zstd installations:
+
+```bash
+cmake -S externals/asam-osi-utilities -B build-deps \
+      --preset base \
+      -DCMAKE_PREFIX_PATH=/path/to/custom/lz4:/path/to/custom/zstd
+```
+
+### Static vs shared OSI linking
+
+By default, OSIUtilities links against the **static position-independent** OSI
+library (`open_simulation_interface_pic`). To link against the shared library
+instead:
+
+```bash
+cmake ... -DLINK_WITH_SHARED_OSI=ON
+```
+
+---
+
+## Dependency Visibility Reference
+
+Understanding which dependencies are transitive helps when diagnosing build
+issues or integrating into projects with existing dependency trees.
+
+| Dependency | Visibility | In public API | Notes |
+| --- | --- | --- | --- |
+| **protobuf** | PUBLIC | `google::protobuf::Message` in `ReadResult`, `Descriptor*` in `AddChannel()` | Must be ABI-compatible between library and consumer |
+| **OSI** (open_simulation_interface) | PUBLIC | Consumers instantiate `WriteMessage<osi3::GroundTruth>()` etc. | Built from proto source via osi-cpp submodule |
+| **mcap** | PUBLIC (headers) | `mcap::McapWriterOptions`, `ReadMessageOptions`, `Metadata` in public methods | Header-only library, bundled |
+| **lz4** | PRIVATE | Not in any public header | Linked internally for MCAP compression |
+| **zstd** | PRIVATE | Not in any public header | Linked internally for MCAP compression |
+| **abseil** | Transitive (via protobuf) | Not directly used | Required by protobuf ≥ 4.x at link time |
+| **utf8_range** | Transitive (via protobuf) | Not directly used | Required by protobuf ≥ 4.x at link time |
+
+### What this means for consumers
+
+- You **do not** need to `find_package(Protobuf)` or `find_package(lz4)` — they
+  are resolved automatically through the OSIUtilities CMake config.
+- If your project already uses protobuf, ensure it is the **same version** used
+  to build OSIUtilities. Mixing versions causes undefined behavior.
+- If your project already uses lz4/zstd, there is no conflict — they are private
+  to OSIUtilities and will not pollute your include paths.
+
+---
+
+## Troubleshooting
+
+### `find_package(OSIUtilities)` fails
+
+Ensure `CMAKE_PREFIX_PATH` includes the install prefix:
+
+```bash
+cmake -S . -B build -DCMAKE_PREFIX_PATH=/path/to/deps
+```
+
+### Protobuf not found (during `find_package(OSIUtilities)`)
+
+The OSIUtilities config calls `find_dependency(Protobuf)` internally. If this
+fails, protobuf is not findable from your build environment. Solutions:
+
+- **Two-phase build:** Pass `VCPKG_INSTALLED_DIR` and `VCPKG_MANIFEST_MODE=OFF`
+  so the vcpkg toolchain finds the pre-installed protobuf.
+- **System packages:** Ensure `libprotobuf-dev` (or equivalent) is installed.
+- **Manual:** Set `Protobuf_DIR` or `CMAKE_PREFIX_PATH` to your protobuf install.
+
+### Abseil linker errors
+
+If you see unresolved `absl::` symbols, protobuf was likely found via CMake's
+built-in `FindProtobuf` module (which doesn't know about abseil) instead of
+protobuf's own config-mode package. Fix: use the vcpkg toolchain or explicitly
+request config mode:
+
+```cmake
+find_package(Protobuf CONFIG REQUIRED)  # before find_package(OSIUtilities)
+```
+
+### Symbol conflicts with existing protobuf
+
+If your project links a different protobuf version, you will get linker errors
+or runtime crashes. Ensure a single protobuf version across the entire build.
+The two-phase build (Method A) is safest because it isolates the dependency
+resolution.
+
+---
+
+## Next Steps
+
+- [Building](building.md) — Build the library itself
+- [Examples](examples.md) — Code examples for readers and writers
+- [API Reference](cpp/index.rst) — Full C++ API documentation

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "asam-osi-utilities",
-  "version-string": "0.3.0",
+  "version-string": "0.3.1",
   "description": "A utility library for working with ASAM Open Simulation Interface (OSI)",
   "homepage": "https://github.com/lichtblick-suite/asam-osi-utilities",
   "dependencies": ["protobuf", "lz4", "zstd"],


### PR DESCRIPTION
## Summary

Add proper CMake package configuration support so that downstream projects (e.g. [esmini](https://github.com/esmini/esmini)) can consume OSIUtilities via the standard CMake `find_package()` mechanism after a two-phase build-and-install workflow:

```cmake
find_package(OSIUtilities REQUIRED)
target_link_libraries(my_target PRIVATE OSIUtilities::OSIUtilities)
```

This is a prerequisite for integrating MCAP trace file writing into esmini, replacing its legacy pre-built OSI 3.5.0 binary downloads with the modern osi-cpp source build provided by this library.

## Breaking Changes

### Install tree layout changed

Removing `EXCLUDE_FROM_ALL` from the osi-cpp `add_subdirectory()` means `cmake --install` now **also installs osi-cpp artifacts** (OSI `.pb.h` headers, `libopen_simulation_interface*.lib`, and cmake config files) alongside OSIUtilities. Previously only OSIUtilities headers and library were installed.

CI/CD scripts or packaging steps that rely on the exact install layout may need updating.

### Transitive dependency propagation

OSI and protobuf are now linked **PUBLIC** instead of PRIVATE. Consumers linking OSIUtilities will transitively get:
- OSI headers (`osi3/*.pb.h`) on their include path
- `protobuf::libprotobuf` (and transitively abseil, utf8_range) on their link line

This is a correction: the public API **requires** these dependencies (`ReadResult::message` is `std::unique_ptr<google::protobuf::Message>`, `AddChannel()` takes `google::protobuf::Descriptor*`, and consumers call `WriteMessage<osi3::GroundTruth>()`). With PRIVATE linking, consumers could not compile against the API without manually finding the same dependencies.

**lz4 and zstd remain PRIVATE** — they have zero public header exposure and are only used internally by the MCAP compression implementation.

## Dependency Visibility Analysis

Based on a thorough analysis of all 12 public headers in `cpp/include/osi-utilities/`:

| Dependency | Linking | Rationale |
|------------|---------|-----------|
| **protobuf** | `PUBLIC` | `google::protobuf::Message` in `ReadResult` struct, `Descriptor*` in `AddChannel()` |
| **OSI** (open_simulation_interface) | `PUBLIC` | Consumers need OSI headers for `WriteMessage<osi3::GroundTruth>()` template instantiation |
| **mcap** | `PUBLIC` (headers) | `mcap::McapWriterOptions`, `ReadMessageOptions`, `Metadata`, `McapWriter*` in public signatures |
| **lz4** | `PRIVATE` | Zero public header exposure — used internally by MCAP compression |
| **zstd** | `PRIVATE` | Zero public header exposure — used internally by MCAP compression |

### External / consumer-provided protobuf

Since protobuf is in the public ABI surface, the consumer and OSIUtilities **must use the same protobuf version** to avoid ODR violations. The `find_dependency(Protobuf)` call in the package config ensures this naturally:

1. Consumer builds Phase A (asam-osi-utilities) with their protobuf (vcpkg, system, conan)
2. OSIUtilities + OSI are compiled against that protobuf version
3. Consumer's Phase B calls `find_package(OSIUtilities)` → config calls `find_dependency(Protobuf)` → finds the **same** protobuf
4. Consistency is guaranteed as long as both phases share the same install prefix or `CMAKE_PREFIX_PATH`

Consumers who already provide protobuf are not forced to use a different version — the two-phase build naturally uses whatever protobuf is available in the build environment.

## Changes

### New file: `cpp/cmake/OSIUtilitiesConfig.cmake.in`

Package configuration template that enables `find_package(OSIUtilities)`. It:

- Calls `find_dependency(open_simulation_interface)` to locate the bundled osi-cpp targets
- Handles the **non-standard Windows install path** (`CMake/open_simulation_interface-<major>/`) by appending both the install prefix and its `CMake/` subdirectory to `CMAKE_PREFIX_PATH`
- Ships `FindCompression.cmake` alongside the config so consumers can locate lz4/zstd the same way the library itself does
- Includes the exported `OSIUtilitiesTargets.cmake` for the `OSIUtilities::OSIUtilities` imported target

### Modified: `cpp/src/CMakeLists.txt`

- **ALIAS target**: Added `OSIUtilities::OSIUtilities` alias for consistent namespaced usage in both build-tree (`add_subdirectory`) and install-tree (`find_package`) scenarios
- **PUBLIC linking** (OSI only): Changed OSI from `PRIVATE` to `PUBLIC` — required because the public API exposes `google::protobuf::Message`, `google::protobuf::Descriptor*`, and consumers instantiate `WriteMessage<osi3::*>()` templates
- **PRIVATE linking** (lz4, zstd): Changed from `PRIVATE` to `PRIVATE` (no change) — these have zero public header exposure
- **install(EXPORT)**: Added export set `OSIUtilitiesTargets` with `OSIUtilities::` namespace
- **Package config generation**: `configure_package_config_file()` + `write_basic_package_version_file()` with `SameMajorVersion` compatibility
- **Build-tree export**: `export(EXPORT ...)` so the library works from the build tree without installation (useful for `add_subdirectory` super-builds)
- **Install destinations**: Added `INCLUDES DESTINATION` to the install targets rule and `INSTALL_INTERFACE` generator expression for MCAP headers

### Modified: `CMakeLists.txt` (root)

- **Removed `EXCLUDE_FROM_ALL`** from the osi-cpp `add_subdirectory()` call — this was preventing osi-cpp's own install targets from running, which meant `cmake --install` would not install OSI headers, libraries, or cmake config files
- **Added `WINDOWS_EXPORT_ALL_SYMBOLS`** for the shared OSI library target on Windows/MSVC — osi-cpp's shared library does not declare `__declspec(dllexport)` symbols, so MSVC never generates the import `.lib` file. This property makes CMake auto-export all symbols, fixing the install-tree targets validation

### Modified: `vcpkg.json`

- Version bump `0.3.0` → `0.3.1`

## Consumer usage (two-phase build)

```bash
# Phase A: Build and install asam-osi-utilities
cmake -S externals/asam-osi-utilities -B build-deps --preset vcpkg
cmake --build build-deps --config Release
cmake --install build-deps --config Release --prefix deps/

# Phase B: Consumer project uses find_package
cmake -S . -B build \
  -DCMAKE_PREFIX_PATH=deps/ \
  -DCMAKE_TOOLCHAIN_FILE=vcpkg.cmake \
  -DVCPKG_INSTALLED_DIR=build-deps/vcpkg_installed \
  -DVCPKG_MANIFEST_MODE=OFF
cmake --build build --config Release
```

## Verification

Tested end-to-end on **Windows** (MSVC 19.44, VS2022, CMake 4.2) with vcpkg-provided protobuf 5.29.3, lz4, and zstd:

1. ✅ `cmake --preset vcpkg` configures successfully
2. ✅ `cmake --build` compiles OSIUtilities + all OSI targets
3. ✅ `cmake --install` produces correct install tree with both OSIUtilities and osi-cpp cmake configs
4. ✅ Standalone consumer project using `find_package(OSIUtilities REQUIRED)` configures, builds, links, and runs correctly

## Install tree layout

```
<prefix>/
├── include/
│   ├── osi3/            (generated .pb.h headers from osi-cpp)
│   ├── osi-utilities/   (library public headers)
│   └── mcap/            (header-only MCAP library)
├── lib/
│   ├── OSIUtilities.lib
│   ├── open_simulation_interface_pic.lib
│   ├── open_simulation_interface_static.lib
│   ├── open_simulation_interface.lib  (import lib, Windows only)
│   ├── open_simulation_interface.dll
│   └── cmake/
│       └── OSIUtilities/
│           ├── OSIUtilitiesConfig.cmake
│           ├── OSIUtilitiesConfigVersion.cmake
│           ├── OSIUtilitiesTargets.cmake
│           ├── OSIUtilitiesTargets-release.cmake
│           └── FindCompression.cmake
└── CMake/  (Windows) or lib/cmake/ (Unix)
    └── open_simulation_interface-3/
        ├── open_simulation_interface-config.cmake
        ├── open_simulation_interface-targets.cmake
        └── ...
```