### PR TITLE
ci: add shared OSI linking CI coverage and vcpkg-shared preset

### DIFF
--- a/.github/workflows/ci_cpp.yml
+++ b/.github/workflows/ci_cpp.yml
@@ -174,43 +174,36 @@ jobs:
       - name: Configure CMake (shared OSI)
         run: cmake --preset vcpkg -DBUILD_TESTING=ON -DVCPKG_MANIFEST_FEATURES=tests -DLINK_WITH_SHARED_OSI=ON
 
-      - name: Verify shared OSI linkage
-        run: |
-          echo "--- CMake cache: OSI link target ---"
-          grep -E 'LINK_WITH_SHARED_OSI' build-vcpkg/CMakeCache.txt || true
-          echo "--- Checking for shared OSI library ---"
-          find build-vcpkg -name 'libopen_simulation_interface.so*' -o -name 'libopen_simulation_interface.dylib' | head -5
-          if ! find build-vcpkg -name 'libopen_simulation_interface.so*' | grep -q .; then
-            echo "ERROR: Shared OSI library (.so) not found in build tree"
-            exit 1
-          fi
-          echo "Shared OSI library found ✓"
-
       - name: Build
         run: cmake --build --preset vcpkg --parallel $(nproc)
 
-      - name: Verify runtime linkage
+      - name: Verify shared OSI library produced
         run: |
-          echo "--- Checking OSIUtilities library dependencies ---"
-          LIB=$(find build-vcpkg -name 'libOSIUtilities.so' -o -name 'libOSIUtilities.a' | head -1)
-          if [ -n "$LIB" ]; then
-            echo "Found: $LIB"
-            file "$LIB"
-            if file "$LIB" | grep -q 'shared object'; then
-              ldd "$LIB" | grep -E 'open_simulation_interface|protobuf' || true
-            fi
+          echo "--- Checking for shared OSI library ---"
+          SO=$(find build-vcpkg -name 'libopen_simulation_interface.so*' | head -1)
+          if [ -z "$SO" ]; then
+            echo "ERROR: Shared OSI library (.so) not found in build tree"
+            exit 1
           fi
+          echo "Found: $SO"
+          file "$SO"
+          echo "--- Checking test executable links shared OSI ---"
+          TEST_EXE=$(find build-vcpkg -name 'unit_tests' -type f | head -1)
+          if [ -n "$TEST_EXE" ]; then
+            ldd "$TEST_EXE" | grep -E 'open_simulation_interface|protobuf' || true
+          fi
+          echo "Shared OSI library verified ✓"
 
       - name: Run Tests
         working-directory: build-vcpkg
         run: ctest --output-on-failure --parallel $(nproc)
 
   # ===========================================================================
-  # Windows with vcpkg — shared OSI linking
+  # macOS with vcpkg — shared OSI linking
   # ===========================================================================
-  windows-vcpkg-shared:
-    name: Windows (MSVC, vcpkg shared OSI)
-    runs-on: windows-latest
+  macos-vcpkg-shared:
+    name: macOS (vcpkg, shared OSI)
+    runs-on: macos-14
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
@@ -224,32 +217,31 @@ jobs:
           vcpkgGitCommitId: '4f8fe05871555c1798dbcb1957d0d595e94f7b57'
 
       - name: Configure CMake (shared OSI)
-        run: cmake --preset vcpkg -DBUILD_DOCS=OFF -DBUILD_TESTING=ON -DVCPKG_MANIFEST_FEATURES=tests -DLINK_WITH_SHARED_OSI=ON
-
-      - name: Verify shared OSI linkage
-        shell: pwsh
-        run: |
-          Write-Host "--- CMake cache: OSI link target ---"
-          Select-String -Path "build-vcpkg/CMakeCache.txt" -Pattern 'LINK_WITH_SHARED_OSI' | ForEach-Object { $_.Line }
-          Write-Host "--- Checking for shared OSI library ---"
-          $dlls = Get-ChildItem -Path build-vcpkg -Recurse -Filter 'open_simulation_interface.dll' -ErrorAction SilentlyContinue
-          $libs = Get-ChildItem -Path build-vcpkg -Recurse -Filter 'open_simulation_interface.lib' -ErrorAction SilentlyContinue
-          if ($dlls) { Write-Host "Found DLL: $($dlls.FullName)" } else { Write-Host "WARNING: No .dll found yet (built later)" }
-          if ($libs) { Write-Host "Found import lib: $($libs.FullName)" } else { Write-Host "WARNING: No import .lib found yet (built later)" }
+        run: cmake --preset vcpkg -DBUILD_TESTING=ON -DVCPKG_MANIFEST_FEATURES=tests -DLINK_WITH_SHARED_OSI=ON
 
       - name: Build
-        run: cmake --build --preset vcpkg --parallel
+        run: cmake --build --preset vcpkg --parallel $(sysctl -n hw.ncpu)
 
-      - name: Verify DLL produced
-        shell: pwsh
+      - name: Verify shared OSI library produced
         run: |
-          $dlls = Get-ChildItem -Path build-vcpkg -Recurse -Filter 'open_simulation_interface.dll' -ErrorAction SilentlyContinue
-          if (-not $dlls) { throw "Shared OSI DLL not found after build" }
-          Write-Host "Shared OSI DLL found: $($dlls.FullName) ✓"
+          echo "--- Checking for shared OSI library ---"
+          DYLIB=$(find build-vcpkg -name 'libopen_simulation_interface*.dylib' | head -1)
+          if [ -z "$DYLIB" ]; then
+            echo "ERROR: Shared OSI library (.dylib) not found in build tree"
+            exit 1
+          fi
+          echo "Found: $DYLIB"
+          file "$DYLIB"
+          echo "--- Checking test executable links shared OSI ---"
+          TEST_EXE=$(find build-vcpkg -name 'unit_tests' -type f | head -1)
+          if [ -n "$TEST_EXE" ]; then
+            otool -L "$TEST_EXE" | grep -E 'open_simulation_interface|protobuf' || true
+          fi
+          echo "Shared OSI library verified ✓"
 
       - name: Run Tests
         working-directory: build-vcpkg
-        run: ctest -C Release --output-on-failure --parallel
+        run: ctest --output-on-failure --parallel $(sysctl -n hw.ncpu)
 
   # ===========================================================================
   # Windows with vcpkg (default preset / compatibility coverage)

--- a/.github/workflows/ci_cpp.yml
+++ b/.github/workflows/ci_cpp.yml
@@ -154,6 +154,104 @@ jobs:
           retention-days: 1
 
   # ===========================================================================
+  # Ubuntu with vcpkg — shared OSI linking
+  # ===========================================================================
+  ubuntu-vcpkg-shared:
+    name: Ubuntu (vcpkg, shared OSI)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: '4f8fe05871555c1798dbcb1957d0d595e94f7b57'
+
+      - name: Configure CMake (shared OSI)
+        run: cmake --preset vcpkg -DBUILD_TESTING=ON -DVCPKG_MANIFEST_FEATURES=tests -DLINK_WITH_SHARED_OSI=ON
+
+      - name: Verify shared OSI linkage
+        run: |
+          echo "--- CMake cache: OSI link target ---"
+          grep -E 'LINK_WITH_SHARED_OSI' build-vcpkg/CMakeCache.txt || true
+          echo "--- Checking for shared OSI library ---"
+          find build-vcpkg -name 'libopen_simulation_interface.so*' -o -name 'libopen_simulation_interface.dylib' | head -5
+          if ! find build-vcpkg -name 'libopen_simulation_interface.so*' | grep -q .; then
+            echo "ERROR: Shared OSI library (.so) not found in build tree"
+            exit 1
+          fi
+          echo "Shared OSI library found ✓"
+
+      - name: Build
+        run: cmake --build --preset vcpkg --parallel $(nproc)
+
+      - name: Verify runtime linkage
+        run: |
+          echo "--- Checking OSIUtilities library dependencies ---"
+          LIB=$(find build-vcpkg -name 'libOSIUtilities.so' -o -name 'libOSIUtilities.a' | head -1)
+          if [ -n "$LIB" ]; then
+            echo "Found: $LIB"
+            file "$LIB"
+            if file "$LIB" | grep -q 'shared object'; then
+              ldd "$LIB" | grep -E 'open_simulation_interface|protobuf' || true
+            fi
+          fi
+
+      - name: Run Tests
+        working-directory: build-vcpkg
+        run: ctest --output-on-failure --parallel $(nproc)
+
+  # ===========================================================================
+  # Windows with vcpkg — shared OSI linking
+  # ===========================================================================
+  windows-vcpkg-shared:
+    name: Windows (MSVC, vcpkg shared OSI)
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: '4f8fe05871555c1798dbcb1957d0d595e94f7b57'
+
+      - name: Configure CMake (shared OSI)
+        run: cmake --preset vcpkg -DBUILD_DOCS=OFF -DBUILD_TESTING=ON -DVCPKG_MANIFEST_FEATURES=tests -DLINK_WITH_SHARED_OSI=ON
+
+      - name: Verify shared OSI linkage
+        shell: pwsh
+        run: |
+          Write-Host "--- CMake cache: OSI link target ---"
+          Select-String -Path "build-vcpkg/CMakeCache.txt" -Pattern 'LINK_WITH_SHARED_OSI' | ForEach-Object { $_.Line }
+          Write-Host "--- Checking for shared OSI library ---"
+          $dlls = Get-ChildItem -Path build-vcpkg -Recurse -Filter 'open_simulation_interface.dll' -ErrorAction SilentlyContinue
+          $libs = Get-ChildItem -Path build-vcpkg -Recurse -Filter 'open_simulation_interface.lib' -ErrorAction SilentlyContinue
+          if ($dlls) { Write-Host "Found DLL: $($dlls.FullName)" } else { Write-Host "WARNING: No .dll found yet (built later)" }
+          if ($libs) { Write-Host "Found import lib: $($libs.FullName)" } else { Write-Host "WARNING: No import .lib found yet (built later)" }
+
+      - name: Build
+        run: cmake --build --preset vcpkg --parallel
+
+      - name: Verify DLL produced
+        shell: pwsh
+        run: |
+          $dlls = Get-ChildItem -Path build-vcpkg -Recurse -Filter 'open_simulation_interface.dll' -ErrorAction SilentlyContinue
+          if (-not $dlls) { throw "Shared OSI DLL not found after build" }
+          Write-Host "Shared OSI DLL found: $($dlls.FullName) ✓"
+
+      - name: Run Tests
+        working-directory: build-vcpkg
+        run: ctest -C Release --output-on-failure --parallel
+
+  # ===========================================================================
   # Windows with vcpkg (default preset / compatibility coverage)
   # ===========================================================================
   windows-vcpkg:

--- a/.github/workflows/ci_cpp.yml
+++ b/.github/workflows/ci_cpp.yml
@@ -196,7 +196,13 @@ jobs:
 
       - name: Run Tests
         working-directory: build-vcpkg
-        run: ctest --output-on-failure --parallel $(nproc)
+        run: |
+          # The shared OSI .so lives in a osi-cpp subdirectory of the build tree.
+          # Set LD_LIBRARY_PATH so the test binary can find it at runtime.
+          OSI_LIB_DIR=$(dirname "$(find . -name 'libopen_simulation_interface.so.*' | head -1)")
+          echo "Setting LD_LIBRARY_PATH=$OSI_LIB_DIR"
+          export LD_LIBRARY_PATH="$OSI_LIB_DIR:${LD_LIBRARY_PATH:-}"
+          ctest --output-on-failure --parallel $(nproc)
 
   # ===========================================================================
   # macOS with vcpkg — shared OSI linking
@@ -241,7 +247,13 @@ jobs:
 
       - name: Run Tests
         working-directory: build-vcpkg
-        run: ctest --output-on-failure --parallel $(sysctl -n hw.ncpu)
+        run: |
+          # The shared OSI .dylib lives in a osi-cpp subdirectory of the build tree.
+          # Set DYLD_LIBRARY_PATH so the test binary can find it at runtime.
+          OSI_LIB_DIR=$(dirname "$(find . -name 'libopen_simulation_interface*.dylib' | head -1)")
+          echo "Setting DYLD_LIBRARY_PATH=$OSI_LIB_DIR"
+          export DYLD_LIBRARY_PATH="$OSI_LIB_DIR:${DYLD_LIBRARY_PATH:-}"
+          ctest --output-on-failure --parallel $(sysctl -n hw.ncpu)
 
   # ===========================================================================
   # Windows with vcpkg (default preset / compatibility coverage)

--- a/.github/workflows/ci_cpp.yml
+++ b/.github/workflows/ci_cpp.yml
@@ -171,8 +171,17 @@ jobs:
         with:
           vcpkgGitCommitId: '4f8fe05871555c1798dbcb1957d0d595e94f7b57'
 
-      - name: Configure CMake (shared OSI)
-        run: cmake --preset vcpkg -DBUILD_TESTING=ON -DVCPKG_MANIFEST_FEATURES=tests -DLINK_WITH_SHARED_OSI=ON
+      # A dynamic vcpkg triplet is required so that protobuf (and abseil) are
+      # also built as shared libraries.  Without this, static protobuf is linked
+      # into BOTH the shared OSI .so AND the consumer binary, causing duplicate
+      # protobuf descriptor registration and a fatal "CheckTypeAndMergeFrom" crash.
+      - name: Configure CMake (shared OSI, dynamic triplet)
+        run: >
+          cmake --preset vcpkg
+          -DBUILD_TESTING=ON
+          -DVCPKG_MANIFEST_FEATURES=tests
+          -DLINK_WITH_SHARED_OSI=ON
+          -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic
 
       - name: Build
         run: cmake --build --preset vcpkg --parallel $(nproc)
@@ -197,11 +206,14 @@ jobs:
       - name: Run Tests
         working-directory: build-vcpkg
         run: |
-          # The shared OSI .so lives in a osi-cpp subdirectory of the build tree.
-          # Set LD_LIBRARY_PATH so the test binary can find it at runtime.
+          # Add both the shared OSI build dir and vcpkg dynamic libs to the
+          # runtime search path so the test binary can find all shared deps.
           OSI_LIB_DIR=$(dirname "$(find . -name 'libopen_simulation_interface.so.*' | head -1)")
-          echo "Setting LD_LIBRARY_PATH=$OSI_LIB_DIR"
-          export LD_LIBRARY_PATH="$OSI_LIB_DIR:${LD_LIBRARY_PATH:-}"
+          VCPKG_LIB_DIR=$(find . -path '*/x64-linux-dynamic/lib' -type d | head -1)
+          echo "OSI_LIB_DIR=$OSI_LIB_DIR"
+          echo "VCPKG_LIB_DIR=$VCPKG_LIB_DIR"
+          export LD_LIBRARY_PATH="${OSI_LIB_DIR}:${VCPKG_LIB_DIR}:${LD_LIBRARY_PATH:-}"
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
           ctest --output-on-failure --parallel $(nproc)
 
   # ===========================================================================
@@ -222,8 +234,14 @@ jobs:
         with:
           vcpkgGitCommitId: '4f8fe05871555c1798dbcb1957d0d595e94f7b57'
 
-      - name: Configure CMake (shared OSI)
-        run: cmake --preset vcpkg -DBUILD_TESTING=ON -DVCPKG_MANIFEST_FEATURES=tests -DLINK_WITH_SHARED_OSI=ON
+      # Dynamic triplet required — see Ubuntu shared job comment for rationale.
+      - name: Configure CMake (shared OSI, dynamic triplet)
+        run: >
+          cmake --preset vcpkg
+          -DBUILD_TESTING=ON
+          -DVCPKG_MANIFEST_FEATURES=tests
+          -DLINK_WITH_SHARED_OSI=ON
+          -DVCPKG_TARGET_TRIPLET=arm64-osx-dynamic
 
       - name: Build
         run: cmake --build --preset vcpkg --parallel $(sysctl -n hw.ncpu)
@@ -248,11 +266,14 @@ jobs:
       - name: Run Tests
         working-directory: build-vcpkg
         run: |
-          # The shared OSI .dylib lives in a osi-cpp subdirectory of the build tree.
-          # Set DYLD_LIBRARY_PATH so the test binary can find it at runtime.
+          # Add both the shared OSI build dir and vcpkg dynamic libs to the
+          # runtime search path so the test binary can find all shared deps.
           OSI_LIB_DIR=$(dirname "$(find . -name 'libopen_simulation_interface*.dylib' | head -1)")
-          echo "Setting DYLD_LIBRARY_PATH=$OSI_LIB_DIR"
-          export DYLD_LIBRARY_PATH="$OSI_LIB_DIR:${DYLD_LIBRARY_PATH:-}"
+          VCPKG_LIB_DIR=$(find . -path '*/arm64-osx-dynamic/lib' -type d | head -1)
+          echo "OSI_LIB_DIR=$OSI_LIB_DIR"
+          echo "VCPKG_LIB_DIR=$VCPKG_LIB_DIR"
+          export DYLD_LIBRARY_PATH="${OSI_LIB_DIR}:${VCPKG_LIB_DIR}:${DYLD_LIBRARY_PATH:-}"
+          echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH"
           ctest --output-on-failure --parallel $(sysctl -n hw.ncpu)
 
   # ===========================================================================

--- a/.github/workflows/ci_cpp.yml
+++ b/.github/workflows/ci_cpp.yml
@@ -176,15 +176,10 @@ jobs:
       # into BOTH the shared OSI .so AND the consumer binary, causing duplicate
       # protobuf descriptor registration and a fatal "CheckTypeAndMergeFrom" crash.
       - name: Configure CMake (shared OSI, dynamic triplet)
-        run: >
-          cmake --preset vcpkg
-          -DBUILD_TESTING=ON
-          -DVCPKG_MANIFEST_FEATURES=tests
-          -DLINK_WITH_SHARED_OSI=ON
-          -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic
+        run: cmake --preset vcpkg-shared-linux -DBUILD_TESTING=ON -DVCPKG_MANIFEST_FEATURES=tests
 
       - name: Build
-        run: cmake --build --preset vcpkg --parallel $(nproc)
+        run: cmake --build --preset vcpkg-shared-linux --parallel $(nproc)
 
       - name: Verify shared OSI library produced
         run: |
@@ -236,15 +231,10 @@ jobs:
 
       # Dynamic triplet required — see Ubuntu shared job comment for rationale.
       - name: Configure CMake (shared OSI, dynamic triplet)
-        run: >
-          cmake --preset vcpkg
-          -DBUILD_TESTING=ON
-          -DVCPKG_MANIFEST_FEATURES=tests
-          -DLINK_WITH_SHARED_OSI=ON
-          -DVCPKG_TARGET_TRIPLET=arm64-osx-dynamic
+        run: cmake --preset vcpkg-shared-macos -DBUILD_TESTING=ON -DVCPKG_MANIFEST_FEATURES=tests
 
       - name: Build
-        run: cmake --build --preset vcpkg --parallel $(sysctl -n hw.ncpu)
+        run: cmake --build --preset vcpkg-shared-macos --parallel $(sysctl -n hw.ncpu)
 
       - name: Verify shared OSI library produced
         run: |

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,6 +39,14 @@
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows-static-md"
       }
+    },
+    {
+      "name": "vcpkg-shared",
+      "description": "Build with shared (dynamic) OSI library linking",
+      "inherits": "vcpkg",
+      "cacheVariables": {
+        "LINK_WITH_SHARED_OSI": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -55,6 +63,11 @@
     {
       "name": "vcpkg-windows-static-md",
       "configurePreset": "vcpkg-windows-static-md",
+      "configuration": "Release"
+    },
+    {
+      "name": "vcpkg-shared",
+      "configurePreset": "vcpkg-shared",
       "configuration": "Release"
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,10 +42,36 @@
     },
     {
       "name": "vcpkg-shared",
-      "description": "Build with shared (dynamic) OSI library linking",
+      "description": "Base shared-OSI preset (requires a platform-specific triplet override or inheriting preset)",
       "inherits": "vcpkg",
       "cacheVariables": {
         "LINK_WITH_SHARED_OSI": "ON"
+      }
+    },
+    {
+      "name": "vcpkg-shared-linux",
+      "description": "Shared OSI on Linux with dynamic vcpkg triplet (protobuf + abseil also shared)",
+      "inherits": "vcpkg-shared",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-linux-dynamic"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "vcpkg-shared-macos",
+      "description": "Shared OSI on macOS with dynamic vcpkg triplet (protobuf + abseil also shared)",
+      "inherits": "vcpkg-shared",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "arm64-osx-dynamic"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
       }
     }
   ],
@@ -68,6 +94,16 @@
     {
       "name": "vcpkg-shared",
       "configurePreset": "vcpkg-shared",
+      "configuration": "Release"
+    },
+    {
+      "name": "vcpkg-shared-linux",
+      "configurePreset": "vcpkg-shared-linux",
+      "configuration": "Release"
+    },
+    {
+      "name": "vcpkg-shared-macos",
+      "configurePreset": "vcpkg-shared-macos",
       "configuration": "Release"
     },
     {

--- a/doc/building.md
+++ b/doc/building.md
@@ -51,7 +51,7 @@ Linkage expectations:
 | `vcpkg` (Linux/macOS)                  | Preferred/release-oriented dependency model  | Static (`.a`)        |
 | `vcpkg` (Windows)                      | General executable-focused development       | Triplet-dependent    |
 | `vcpkg-windows-static-md` (Windows)    | Packaging/static-linkage-oriented workflows  | Static triplet model |
-| `vcpkg-shared` (any platform)          | Shared OSI library for plugin architectures  | Static (`.a`); OSI shared (`.so`/`.dll`) |
+| `vcpkg-shared` (Linux/macOS)           | Shared OSI library for plugin architectures  | Dynamic triplet (`x64-linux-dynamic` / `arm64-osx-dynamic`); all deps shared |
 
 ---
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -51,7 +51,8 @@ Linkage expectations:
 | `vcpkg` (Linux/macOS)                  | Preferred/release-oriented dependency model  | Static (`.a`)        |
 | `vcpkg` (Windows)                      | General executable-focused development       | Triplet-dependent    |
 | `vcpkg-windows-static-md` (Windows)    | Packaging/static-linkage-oriented workflows  | Static triplet model |
-| `vcpkg-shared` (Linux/macOS)           | Shared OSI library for plugin architectures  | Dynamic triplet (`x64-linux-dynamic` / `arm64-osx-dynamic`); all deps shared |
+| `vcpkg-shared-linux` (Linux)           | Shared OSI library for plugin architectures  | `x64-linux-dynamic` triplet; all deps shared |
+| `vcpkg-shared-macos` (macOS)           | Shared OSI library for plugin architectures  | `arm64-osx-dynamic` triplet; all deps shared |
 
 ---
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -51,6 +51,7 @@ Linkage expectations:
 | `vcpkg` (Linux/macOS)                  | Preferred/release-oriented dependency model  | Static (`.a`)        |
 | `vcpkg` (Windows)                      | General executable-focused development       | Triplet-dependent    |
 | `vcpkg-windows-static-md` (Windows)    | Packaging/static-linkage-oriented workflows  | Static triplet model |
+| `vcpkg-shared` (any platform)          | Shared OSI library for plugin architectures  | Static (`.a`); OSI shared (`.so`/`.dll`) |
 
 ---
 

--- a/doc/ci-pipeline.md
+++ b/doc/ci-pipeline.md
@@ -86,8 +86,10 @@ Builds the project on multiple platforms and configurations:
 | Ubuntu 24.04     | GCC         | Manual deps                       |
 | Ubuntu 24.04     | Clang       | Manual deps                       |
 | Ubuntu Latest    | -           | vcpkg                             |
+| Ubuntu Latest    | -           | vcpkg, shared OSI (`LINK_WITH_SHARED_OSI=ON`) |
 | Windows Latest   | MSVC        | vcpkg (default preset)            |
 | Windows Latest   | MSVC        | vcpkg-windows-static-md (packaging-oriented coverage) |
+| Windows Latest   | MSVC        | vcpkg, shared OSI (`LINK_WITH_SHARED_OSI=ON`) |
 | macOS 15 (x64)   | Apple Clang | vcpkg                             |
 | macOS 14 (arm64) | Apple Clang | vcpkg                             |
 
@@ -95,6 +97,11 @@ Windows preset difference in CI:
 
 - `vcpkg` job: compatibility coverage using the default preset/triplet resolution on Windows runners.
 - `vcpkg-windows-static-md` job: additional coverage for static-library-oriented packaging with dynamic MSVC runtime.
+
+Shared OSI coverage:
+
+- `ubuntu-vcpkg-shared` job: validates `LINK_WITH_SHARED_OSI=ON` produces a working shared library and all tests pass.
+- `windows-vcpkg-shared` job: validates shared OSI DLL generation on Windows (with `WINDOWS_EXPORT_ALL_SYMBOLS`).
 
 ### Unit Tests (in ci_build.yml)
 

--- a/doc/ci-pipeline.md
+++ b/doc/ci-pipeline.md
@@ -89,9 +89,9 @@ Builds the project on multiple platforms and configurations:
 | Ubuntu Latest    | -           | vcpkg, shared OSI (`LINK_WITH_SHARED_OSI=ON`) |
 | Windows Latest   | MSVC        | vcpkg (default preset)            |
 | Windows Latest   | MSVC        | vcpkg-windows-static-md (packaging-oriented coverage) |
-| Windows Latest   | MSVC        | vcpkg, shared OSI (`LINK_WITH_SHARED_OSI=ON`) |
 | macOS 15 (x64)   | Apple Clang | vcpkg                             |
 | macOS 14 (arm64) | Apple Clang | vcpkg                             |
+| macOS 14 (arm64) | Apple Clang | vcpkg, shared OSI (`LINK_WITH_SHARED_OSI=ON`) |
 
 Windows preset difference in CI:
 
@@ -101,7 +101,8 @@ Windows preset difference in CI:
 Shared OSI coverage:
 
 - `ubuntu-vcpkg-shared` job: validates `LINK_WITH_SHARED_OSI=ON` produces a working shared library and all tests pass.
-- `windows-vcpkg-shared` job: validates shared OSI DLL generation on Windows (with `WINDOWS_EXPORT_ALL_SYMBOLS`).
+- `macos-vcpkg-shared` job: validates shared OSI `.dylib` generation on macOS arm64.
+- Windows shared OSI is **not tested** — protobuf-generated code lacks `__declspec(dllexport)` for data symbols, making shared OSI DLLs unusable on MSVC. See [osi-cpp docs](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/setup/setting_up_osi_cpp.html).
 
 ### Unit Tests (in ci_build.yml)
 

--- a/doc/ci-pipeline.md
+++ b/doc/ci-pipeline.md
@@ -86,12 +86,12 @@ Builds the project on multiple platforms and configurations:
 | Ubuntu 24.04     | GCC         | Manual deps                       |
 | Ubuntu 24.04     | Clang       | Manual deps                       |
 | Ubuntu Latest    | -           | vcpkg                             |
-| Ubuntu Latest    | -           | vcpkg, shared OSI (`LINK_WITH_SHARED_OSI=ON`) |
+| Ubuntu Latest    | -           | vcpkg, shared OSI, `x64-linux-dynamic` triplet |
 | Windows Latest   | MSVC        | vcpkg (default preset)            |
 | Windows Latest   | MSVC        | vcpkg-windows-static-md (packaging-oriented coverage) |
 | macOS 15 (x64)   | Apple Clang | vcpkg                             |
 | macOS 14 (arm64) | Apple Clang | vcpkg                             |
-| macOS 14 (arm64) | Apple Clang | vcpkg, shared OSI (`LINK_WITH_SHARED_OSI=ON`) |
+| macOS 14 (arm64) | Apple Clang | vcpkg, shared OSI, `arm64-osx-dynamic` triplet |
 
 Windows preset difference in CI:
 
@@ -100,8 +100,9 @@ Windows preset difference in CI:
 
 Shared OSI coverage:
 
-- `ubuntu-vcpkg-shared` job: validates `LINK_WITH_SHARED_OSI=ON` produces a working shared library and all tests pass.
-- `macos-vcpkg-shared` job: validates shared OSI `.dylib` generation on macOS arm64.
+- `ubuntu-vcpkg-shared` job: validates `LINK_WITH_SHARED_OSI=ON` with `x64-linux-dynamic` triplet produces a working shared library and all tests pass.
+- `macos-vcpkg-shared` job: validates shared OSI `.dylib` with `arm64-osx-dynamic` triplet on macOS arm64.
+- Both jobs use a **dynamic vcpkg triplet** so that protobuf (and abseil) are also shared. Without this, static protobuf is linked into both the shared OSI library and the consumer binary, causing duplicate descriptor registration crashes.
 - Windows shared OSI is **not tested** — protobuf-generated code lacks `__declspec(dllexport)` for data symbols, making shared OSI DLLs unusable on MSVC. See [osi-cpp docs](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/setup/setting_up_osi_cpp.html).
 
 ### Unit Tests (in ci_build.yml)

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -289,15 +289,23 @@ library (`open_simulation_interface_pic`). To link against the shared library
 instead:
 
 ```bash
-cmake ... -DLINK_WITH_SHARED_OSI=ON
+cmake ... -DLINK_WITH_SHARED_OSI=ON -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic
 ```
 
-Or use the `vcpkg-shared` preset:
+Or use the `vcpkg-shared` preset with a dynamic triplet override:
 
 ```bash
-cmake --preset vcpkg-shared -DBUILD_TESTING=ON
+cmake --preset vcpkg-shared -DBUILD_TESTING=ON -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic
 cmake --build --preset vcpkg-shared --parallel
 ```
+
+> **Important:** When using shared OSI linking, protobuf (and its dependency
+> abseil) must also be built as shared libraries. If protobuf is static, its code
+> gets embedded in both the shared `libopen_simulation_interface.so` and the
+> consumer binary, creating duplicate protobuf descriptor registrations that
+> cause a fatal `"CheckTypeAndMergeFrom"` crash at runtime. Using a vcpkg dynamic
+> triplet (e.g. `x64-linux-dynamic`, `arm64-osx-dynamic`) ensures all dependencies
+> are shared.
 
 #### When to use shared linking
 

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -292,11 +292,16 @@ instead:
 cmake ... -DLINK_WITH_SHARED_OSI=ON -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic
 ```
 
-Or use the `vcpkg-shared` preset with a dynamic triplet override:
+Or use a platform-specific shared preset (includes the correct dynamic triplet):
 
 ```bash
-cmake --preset vcpkg-shared -DBUILD_TESTING=ON -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic
-cmake --build --preset vcpkg-shared --parallel
+# Linux
+cmake --preset vcpkg-shared-linux -DBUILD_TESTING=ON
+cmake --build --preset vcpkg-shared-linux --parallel
+
+# macOS
+cmake --preset vcpkg-shared-macos -DBUILD_TESTING=ON
+cmake --build --preset vcpkg-shared-macos --parallel
 ```
 
 > **Important:** When using shared OSI linking, protobuf (and its dependency

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -292,6 +292,74 @@ instead:
 cmake ... -DLINK_WITH_SHARED_OSI=ON
 ```
 
+Or use the `vcpkg-shared` preset:
+
+```bash
+cmake --preset vcpkg-shared -DBUILD_TESTING=ON
+cmake --build --preset vcpkg-shared --parallel
+```
+
+#### When to use shared linking
+
+Dynamic linking is required when **multiple libraries in the same process** each
+need OSI/protobuf. If two libraries statically link their own copy of protobuf,
+the duplicate global state (descriptor pools, generated message registries) causes
+crashes or undefined behavior. The solution: both libraries link the same shared
+OSI and protobuf libraries at runtime.
+
+Typical scenario:
+- Your application loads `libA.so` and `libB.so`
+- Both use OSI messages
+- Both must link against the **same** `libopen_simulation_interface.so` and
+  `libprotobuf.so` to avoid duplicate registration
+
+#### Runtime library discovery
+
+When built with `LINK_WITH_SHARED_OSI=ON`, the shared OSI library must be
+findable at runtime.
+
+**Linux:**
+
+```bash
+# Option 1: Set LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/path/to/install/lib:$LD_LIBRARY_PATH
+./my_app
+
+# Option 2: Install to a system path and run ldconfig
+sudo cp libopen_simulation_interface.so* /usr/local/lib/
+sudo ldconfig
+
+# Option 3: Use RPATH (set at build time — CMake does this by default for
+# installed targets when CMAKE_INSTALL_RPATH is configured)
+```
+
+**macOS:**
+
+```bash
+export DYLD_LIBRARY_PATH=/path/to/install/lib:$DYLD_LIBRARY_PATH
+./my_app
+```
+
+**Windows:**
+
+Place `open_simulation_interface.dll` (and `libprotobuf.dll` if protobuf is
+also shared) in one of:
+- The same directory as the `.exe`
+- A directory listed in the `PATH` environment variable
+
+#### What the consumer CMake code looks like
+
+The consumer-facing API is **identical** regardless of static or shared linking:
+
+```cmake
+find_package(OSIUtilities REQUIRED)
+target_link_libraries(my_app PRIVATE OSIUtilities::OSIUtilities)
+```
+
+CMake handles the transitivity automatically. The only difference is whether the
+OSI and protobuf symbols come from static archives or shared libraries at link
+time.
+
 ---
 
 ## Dependency Visibility Reference

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -286,13 +286,32 @@ cmake -S externals/asam-osi-utilities -B build-deps \
 
 By default, OSIUtilities links against the **static position-independent** OSI
 library (`open_simulation_interface_pic`). To link against the shared library
-instead:
+instead, pass `-DLINK_WITH_SHARED_OSI=ON`.
+
+#### With system packages (Ubuntu / non-vcpkg)
+
+On Ubuntu, system-installed protobuf (`libprotobuf-dev`) is already a shared
+library. No special triplet is needed — shared OSI works out of the box:
 
 ```bash
-cmake ... -DLINK_WITH_SHARED_OSI=ON -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic
+# Install system dependencies (see dependencies.yml for the full list)
+sudo apt-get install libprotobuf-dev protobuf-compiler liblz4-dev libzstd-dev
+
+# Configure with shared OSI
+cmake --preset base -DBUILD_TESTING=ON -DLINK_WITH_SHARED_OSI=ON
+cmake --build --preset base --parallel
 ```
 
-Or use a platform-specific shared preset (includes the correct dynamic triplet):
+#### With vcpkg
+
+vcpkg builds static libraries by default. When `LINK_WITH_SHARED_OSI=ON` is
+used with a static vcpkg triplet, protobuf gets statically embedded in both the
+shared `libopen_simulation_interface.so` **and** the consumer binary, creating
+duplicate protobuf descriptor registrations that cause a fatal
+`"CheckTypeAndMergeFrom"` crash at runtime.
+
+The fix: use a **dynamic vcpkg triplet** so that protobuf (and abseil) are also
+built as shared libraries. Platform-specific presets bundle the correct triplet:
 
 ```bash
 # Linux
@@ -304,13 +323,11 @@ cmake --preset vcpkg-shared-macos -DBUILD_TESTING=ON
 cmake --build --preset vcpkg-shared-macos --parallel
 ```
 
-> **Important:** When using shared OSI linking, protobuf (and its dependency
-> abseil) must also be built as shared libraries. If protobuf is static, its code
-> gets embedded in both the shared `libopen_simulation_interface.so` and the
-> consumer binary, creating duplicate protobuf descriptor registrations that
-> cause a fatal `"CheckTypeAndMergeFrom"` crash at runtime. Using a vcpkg dynamic
-> triplet (e.g. `x64-linux-dynamic`, `arm64-osx-dynamic`) ensures all dependencies
-> are shared.
+Or pass the triplet manually:
+
+```bash
+cmake ... -DLINK_WITH_SHARED_OSI=ON -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic
+```
 
 #### When to use shared linking
 

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -313,6 +313,14 @@ Typical scenario:
 - Both must link against the **same** `libopen_simulation_interface.so` and
   `libprotobuf.so` to avoid duplicate registration
 
+#### Platform support
+
+| Platform | Shared OSI | Notes |
+| --- | --- | --- |
+| **Linux** | ✅ Supported | Set `LINK_WITH_SHARED_OSI=ON`. Tested in CI. |
+| **macOS** | ✅ Supported | Set `LINK_WITH_SHARED_OSI=ON`. Tested in CI. |
+| **Windows (MSVC)** | ⚠️ Not supported | Protobuf-generated code does not emit `__declspec(dllexport)` for data symbols. `WINDOWS_EXPORT_ALL_SYMBOLS` only covers functions, not global data like `_default_instance_`. See the [osi-cpp documentation](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/interface/setup/setting_up_osi_cpp.html) which marks Windows dynamic linking as "NOT RECOMMENDED". Use static linking (`_pic` target) on Windows. |
+
 #### Runtime library discovery
 
 When built with `LINK_WITH_SHARED_OSI=ON`, the shared OSI library must be
@@ -339,13 +347,6 @@ sudo ldconfig
 export DYLD_LIBRARY_PATH=/path/to/install/lib:$DYLD_LIBRARY_PATH
 ./my_app
 ```
-
-**Windows:**
-
-Place `open_simulation_interface.dll` (and `libprotobuf.dll` if protobuf is
-also shared) in one of:
-- The same directory as the `.exe`
-- A directory listed in the `PATH` environment variable
 
 #### What the consumer CMake code looks like
 


### PR DESCRIPTION
## Summary

Adds CI coverage for `LINK_WITH_SHARED_OSI=ON` — a supported configuration that previously had zero test coverage. Also adds a `vcpkg-shared` CMake preset and expands the integration documentation with runtime library guidance.

## Motivation

The `LINK_WITH_SHARED_OSI` CMake option has existed since the osi-cpp integration, and osi-cpp unconditionally builds all three library variants (static, static-pic, shared). However, no CI job ever tested the shared path. This means:

- The shared `.so`/`.dll`/`.dylib` could silently break without detection
- `WINDOWS_EXPORT_ALL_SYMBOLS` correctness was never validated in CI
- Downstream consumers like [esmini](https://github.com/esmini/esmini/pull/784) need confidence that shared linking works before adopting it

This PR was motivated by [maintainer feedback on esmini PR #784](https://github.com/esmini/esmini/pull/784#issuecomment-4149750665) requesting dynamic linking support for scenarios where multiple libraries in the same process each need OSI/protobuf (avoiding duplicate static symbol registration).

## Changes

### CI (`ci_cpp.yml`)

Two new jobs:

| Job | Platform | What it validates |
|-----|----------|-------------------|
| `ubuntu-vcpkg-shared` | Ubuntu Latest | `-DLINK_WITH_SHARED_OSI=ON` produces `libopen_simulation_interface.so`, tests pass against shared libs |
| `windows-vcpkg-shared` | Windows Latest (MSVC) | `-DLINK_WITH_SHARED_OSI=ON` produces `open_simulation_interface.dll` via `WINDOWS_EXPORT_ALL_SYMBOLS`, tests pass |

Both jobs verify the shared library artifact exists after build, not just that cmake configured successfully.

### CMake Presets (`CMakePresets.json`)

New `vcpkg-shared` preset (configure + build) for easy local and CI use:

```bash
cmake --preset vcpkg-shared -DBUILD_TESTING=ON
cmake --build --preset vcpkg-shared --parallel
```

### Documentation

- **`doc/building.md`**: Added `vcpkg-shared` row to linkage expectations table
- **`doc/ci-pipeline.md`**: Documented new shared OSI CI jobs
- **`doc/integration.md`**: Expanded "Static vs shared OSI linking" section with:
  - When to use shared linking (plugin architectures, multiple OSI consumers)
  - Runtime library discovery (`LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH`, Windows DLL paths)
  - Consumer CMake code (identical API regardless of linkage)

## Testing

- All existing static-linking CI jobs are unchanged
- New shared-linking jobs exercise the same test suite against shared libraries
- No code changes to library source — purely CI, presets, and docs