### PR TITLE
chore: bump version to 0.4.0 and update mcap to v2.1.3

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "asam-osi-utilities",
-  "version-string": "0.3.1",
+  "version-string": "0.4.0",
   "description": "A utility library for working with ASAM Open Simulation Interface (OSI)",
   "homepage": "https://github.com/lichtblick-suite/asam-osi-utilities",
   "dependencies": ["protobuf", "lz4", "zstd"],


### PR DESCRIPTION
## Related Issue

refs #46

## Summary

Prepare release 0.4.0 after merging PR #46 (reader/writer refactor with channel abstraction, unified types, and API parity).

**Changes:**
- Bump `vcpkg.json` version-string from `0.3.1` to `0.4.0`
- Update `submodules/mcap` from `releases/cpp/v2.1.2` to `releases/cpp/v2.1.3` (fixes schemas without messages — [foxglove/mcap#1592](https://github.com/foxglove/mcap/pull/1592))

**Version rationale (SemVer):** Minor bump for new features with no breaking changes:
- C++: ReadStatus enum, TraceFileFormat enum, extended ReadResult, SetSkipIncompatibleMessages/SetLogIncompatibleMessages, polymorphic WriteMessage, TraceFileWriterFactory, type aliases
- Python: ChannelReader/ChannelWriter, ChannelSpecification, configure_reader helpers, unified types
- Deprecations (backward compatible): SetSkipNonOSIMsgs, TXTH reader/writer classes

## Validation

- `cmake --preset vcpkg && cmake --build --preset vcpkg --parallel` — builds clean
- `ctest --test-dir build-vcpkg --output-on-failure -C Release` — 222/222 C++ tests pass
- `python -m pytest python/ -v` — 210/210 Python tests pass
- All 10 C++ examples and 10 Python examples run successfully

## Checklist

- [x] Unit tests added/updated for behavior changes (or N/A with reason). — N/A, version bump and submodule pin only.
- [x] Documentation updated for user-visible/API changes (or N/A with reason). — N/A, no API changes in this commit.
- [x] Local checks pass (`pre-commit`, build, tests).
- [ ] Reviewer(s) assigned.
