### PR TITLE
feat(tracefile): add raw channel support to writers

### DIFF
--- a/cpp/include/osi-utilities/tracefile/writer/MCAPTraceFileChannel.h
+++ b/cpp/include/osi-utilities/tracefile/writer/MCAPTraceFileChannel.h
@@ -110,6 +110,38 @@ class MCAPTraceFileChannel {
     uint16_t AddChannel(const std::string& topic, const google::protobuf::Descriptor* descriptor, std::unordered_map<std::string, std::string> channel_metadata = {});
 
     /**
+     * @brief Adds a non-OSI raw channel to the MCAP file
+     *
+     * Registers a channel with a custom schema. No OSI-specific metadata is added.
+     *
+     * @param topic Name of the channel/topic
+     * @param schema_name Name for the schema
+     * @param schema_encoding Schema encoding (e.g. "ros1msg", "jsonschema")
+     * @param schema_data Serialized schema definition (may be empty)
+     * @param message_encoding Message encoding (e.g. "ros1", "json")
+     * @param channel_metadata Optional metadata for the channel
+     * @return Channel ID for the newly created channel
+     * @throws std::runtime_error if topic already exists
+     */
+    uint16_t AddRawChannel(const std::string& topic, const std::string& schema_name,
+                           const std::string& schema_encoding, const std::string& schema_data,
+                           const std::string& message_encoding,
+                           std::unordered_map<std::string, std::string> channel_metadata = {});
+
+    /**
+     * @brief Writes raw bytes to a registered channel (OSI or non-OSI)
+     *
+     * @param topic The channel topic (must have been registered)
+     * @param data Pointer to the raw message bytes
+     * @param data_size Size of the data in bytes
+     * @param log_time Message timestamp in nanoseconds
+     * @param publish_time Optional publish timestamp (defaults to log_time if 0)
+     * @return true if successful, false otherwise
+     */
+    bool WriteRawMessage(const std::string& topic, const std::byte* data, size_t data_size,
+                         mcap::Timestamp log_time, mcap::Timestamp publish_time = 0);
+
+    /**
      * @brief Prepares the required (by OSI spec) metadata for the MCAP trace file
      *
      * Call this and write the result to your McapWriter before writing OSI messages.

--- a/cpp/include/osi-utilities/tracefile/writer/MCAPTraceFileWriter.h
+++ b/cpp/include/osi-utilities/tracefile/writer/MCAPTraceFileWriter.h
@@ -131,6 +131,38 @@ class MCAPTraceFileWriter final : public osi3::TraceFileWriter {
      */
     mcap::McapWriter* GetMcapWriter() { return &mcap_writer_; }
 
+    /**
+     * @brief Adds a non-OSI raw channel to the MCAP file
+     *
+     * Registers a channel with a custom schema for non-OSI data (e.g. ROS messages,
+     * JSON telemetry). The channel is tracked alongside OSI channels.
+     *
+     * @param topic Name of the channel/topic
+     * @param schema_name Name for the schema (e.g. "sensor_msgs/PointCloud2")
+     * @param schema_encoding Schema encoding (e.g. "ros1msg", "jsonschema")
+     * @param schema_data Serialized schema definition (may be empty)
+     * @param message_encoding Message encoding (e.g. "ros1", "json")
+     * @param channel_metadata Optional metadata for the channel
+     * @return Channel ID for the newly created channel
+     */
+    uint16_t AddRawChannel(const std::string& topic, const std::string& schema_name,
+                           const std::string& schema_encoding, const std::string& schema_data,
+                           const std::string& message_encoding,
+                           std::unordered_map<std::string, std::string> channel_metadata = {});
+
+    /**
+     * @brief Writes raw bytes to a registered channel (OSI or non-OSI)
+     *
+     * @param topic The channel topic (must have been registered)
+     * @param data Pointer to the raw message bytes
+     * @param data_size Size of the data in bytes
+     * @param log_time Message timestamp in nanoseconds
+     * @param publish_time Optional publish timestamp (defaults to log_time if 0)
+     * @return true if successful, false otherwise
+     */
+    bool WriteRawMessage(const std::string& topic, const std::byte* data, size_t data_size,
+                         mcap::Timestamp log_time, mcap::Timestamp publish_time = 0);
+
    private:
     std::ofstream trace_file_;                         /**< Trace file stream */
     mcap::McapWriter mcap_writer_;                     /**< MCAP writer instance */

--- a/cpp/src/tracefile/writer/MCAPTraceFileChannel.cpp
+++ b/cpp/src/tracefile/writer/MCAPTraceFileChannel.cpp
@@ -142,6 +142,53 @@ auto MCAPTraceFileChannel::PrepareRequiredFileMetadata() -> mcap::Metadata { ret
 
 auto MCAPTraceFileChannel::GetCurrentTimeAsString() -> std::string { return mcap_utils::GetCurrentTimeAsString(); }
 
+auto MCAPTraceFileChannel::AddRawChannel(const std::string& topic, const std::string& schema_name,
+                                         const std::string& schema_encoding, const std::string& schema_data,
+                                         const std::string& message_encoding,
+                                         std::unordered_map<std::string, std::string> channel_metadata) -> uint16_t {
+    if (auto it = topic_to_channel_id_.find(topic); it != topic_to_channel_id_.end()) {
+        throw std::runtime_error("Topic '" + topic + "' already exists");
+    }
+
+    mcap::Schema raw_schema(schema_name, schema_encoding, schema_data);
+    mcap_writer_.addSchema(raw_schema);
+
+    mcap::Channel channel(topic, message_encoding, raw_schema.id, channel_metadata);
+    mcap_writer_.addChannel(channel);
+
+    topic_to_channel_id_[topic] = channel.id;
+    topic_to_schema_name_[topic] = schema_name;
+
+    return channel.id;
+}
+
+auto MCAPTraceFileChannel::WriteRawMessage(const std::string& topic, const std::byte* data, size_t data_size,
+                                           mcap::Timestamp log_time, mcap::Timestamp publish_time) -> bool {
+    if (topic.empty()) {
+        std::cerr << "ERROR: cannot write raw message, topic is empty\n";
+        return false;
+    }
+
+    const auto it = topic_to_channel_id_.find(topic);
+    if (it == topic_to_channel_id_.end()) {
+        std::cerr << "ERROR: cannot write raw message, topic " << topic << " not found\n";
+        return false;
+    }
+
+    mcap::Message msg;
+    msg.channelId = it->second;
+    msg.logTime = log_time;
+    msg.publishTime = publish_time != 0 ? publish_time : log_time;
+    msg.data = data;
+    msg.dataSize = data_size;
+
+    if (const auto status = mcap_writer_.write(msg); status.code != mcap::StatusCode::Success) {
+        std::cerr << "ERROR: Failed to write raw message " << status.message;
+        return false;
+    }
+    return true;
+}
+
 // template instantiations of allowed OSI top-level messages
 template bool MCAPTraceFileChannel::WriteMessage<osi3::GroundTruth>(const osi3::GroundTruth&, const std::string&);
 template bool MCAPTraceFileChannel::WriteMessage<osi3::SensorData>(const osi3::SensorData&, const std::string&);

--- a/cpp/src/tracefile/writer/MCAPTraceFileWriter.cpp
+++ b/cpp/src/tracefile/writer/MCAPTraceFileWriter.cpp
@@ -118,6 +118,28 @@ auto MCAPTraceFileWriter::AddChannel(const std::string& topic, const google::pro
     return channel_.AddChannel(topic, descriptor, std::move(channel_metadata));
 }
 
+auto MCAPTraceFileWriter::AddRawChannel(const std::string& topic, const std::string& schema_name,
+                                        const std::string& schema_encoding, const std::string& schema_data,
+                                        const std::string& message_encoding,
+                                        std::unordered_map<std::string, std::string> channel_metadata) -> uint16_t {
+    return channel_.AddRawChannel(topic, schema_name, schema_encoding, schema_data, message_encoding, std::move(channel_metadata));
+}
+
+auto MCAPTraceFileWriter::WriteRawMessage(const std::string& topic, const std::byte* data, size_t data_size,
+                                          mcap::Timestamp log_time, mcap::Timestamp publish_time) -> bool {
+    if (!(trace_file_ && trace_file_.is_open())) {
+        std::cerr << "ERROR: cannot write raw message, file is not open\n";
+        return false;
+    }
+    if (!required_metadata_added_) {
+        if (!AddFileMetadata(PrepareRequiredFileMetadata())) {
+            std::cerr << "ERROR: failed to auto-add required metadata\n";
+            return false;
+        }
+    }
+    return channel_.WriteRawMessage(topic, data, data_size, log_time, publish_time);
+}
+
 auto MCAPTraceFileWriter::GetCurrentTimeAsString() -> std::string { return MCAPTraceFileChannel::GetCurrentTimeAsString(); }
 
 // template instantiations of allowed OSI top-level messages

--- a/cpp/tests/src/tracefile/writer/MCAPTraceFileChannel_test.cpp
+++ b/cpp/tests/src/tracefile/writer/MCAPTraceFileChannel_test.cpp
@@ -303,3 +303,95 @@ TEST_F(MCAPTraceFileChannelTest, ChannelMetadataContainsOSIVersion) {
 
     mcap_reader.close();
 }
+
+TEST_F(MCAPTraceFileChannelTest, AddRawChannel) {
+    OpenWriter();
+
+    osi3::MCAPTraceFileChannel osi_channel(mcap_writer_);
+    const auto channel_id = osi_channel.AddRawChannel(
+        "raw/data", "CustomType", "raw", "", "raw");
+    EXPECT_GT(channel_id, 0);
+
+    CloseWriter();
+}
+
+TEST_F(MCAPTraceFileChannelTest, AddRawChannelDuplicateThrows) {
+    OpenWriter();
+
+    osi3::MCAPTraceFileChannel osi_channel(mcap_writer_);
+    osi_channel.AddRawChannel("raw", "T", "raw", "", "raw");
+    EXPECT_THROW(osi_channel.AddRawChannel("raw", "T2", "raw", "", "raw"), std::runtime_error);
+
+    CloseWriter();
+}
+
+TEST_F(MCAPTraceFileChannelTest, WriteRawMessage) {
+    OpenWriter();
+
+    osi3::MCAPTraceFileChannel osi_channel(mcap_writer_);
+    osi_channel.AddRawChannel("raw/data", "RawType", "raw", "", "raw");
+
+    const std::string payload = "hello_raw";
+    const auto* data = reinterpret_cast<const std::byte*>(payload.data());
+    EXPECT_TRUE(osi_channel.WriteRawMessage("raw/data", data, payload.size(), 5'000'000'000));
+
+    CloseWriter();
+
+    // Verify file has one message
+    std::ifstream file(test_file_, std::ios::binary);
+    mcap::McapReader mcap_reader;
+    ASSERT_TRUE(mcap_reader.open(file).ok());
+    ASSERT_TRUE(mcap_reader.readSummary(mcap::ReadSummaryMethod::AllowFallbackScan).ok());
+    EXPECT_EQ(mcap_reader.statistics()->value().messageCount, 1);
+    mcap_reader.close();
+}
+
+TEST_F(MCAPTraceFileChannelTest, WriteRawUnregisteredTopicFails) {
+    OpenWriter();
+
+    osi3::MCAPTraceFileChannel osi_channel(mcap_writer_);
+    const std::string payload = "data";
+    const auto* data = reinterpret_cast<const std::byte*>(payload.data());
+    EXPECT_FALSE(osi_channel.WriteRawMessage("nonexistent", data, payload.size(), 1));
+
+    CloseWriter();
+}
+
+TEST_F(MCAPTraceFileChannelTest, WriteRawEmptyTopicFails) {
+    OpenWriter();
+
+    osi3::MCAPTraceFileChannel osi_channel(mcap_writer_);
+    const std::string payload = "data";
+    const auto* data = reinterpret_cast<const std::byte*>(payload.data());
+    EXPECT_FALSE(osi_channel.WriteRawMessage("", data, payload.size(), 1));
+
+    CloseWriter();
+}
+
+TEST_F(MCAPTraceFileChannelTest, MixedOSIAndRawChannels) {
+    OpenWriter();
+
+    osi3::MCAPTraceFileChannel osi_channel(mcap_writer_);
+    ASSERT_EQ(mcap_writer_.write(osi3::MCAPTraceFileChannel::PrepareRequiredFileMetadata()).code, mcap::StatusCode::Success);
+
+    osi_channel.AddChannel("osi/gt", osi3::GroundTruth::descriptor());
+    osi_channel.AddRawChannel("raw/data", "CustomType", "raw", "", "raw");
+
+    osi3::GroundTruth gt;
+    gt.mutable_timestamp()->set_seconds(1);
+    ASSERT_TRUE(osi_channel.WriteMessage(gt, "osi/gt"));
+
+    const std::string payload = "raw_payload";
+    const auto* data = reinterpret_cast<const std::byte*>(payload.data());
+    ASSERT_TRUE(osi_channel.WriteRawMessage("raw/data", data, payload.size(), 1'000'000'000));
+
+    CloseWriter();
+
+    // Verify both channels exist
+    std::ifstream file(test_file_, std::ios::binary);
+    mcap::McapReader mcap_reader;
+    ASSERT_TRUE(mcap_reader.open(file).ok());
+    ASSERT_TRUE(mcap_reader.readSummary(mcap::ReadSummaryMethod::AllowFallbackScan).ok());
+    EXPECT_EQ(mcap_reader.channels().size(), 2);
+    mcap_reader.close();
+}

--- a/cpp/tests/src/tracefile/writer/MCAPTraceFileWriter_test.cpp
+++ b/cpp/tests/src/tracefile/writer/MCAPTraceFileWriter_test.cpp
@@ -342,3 +342,59 @@ TEST_F(MCAPTraceFileWriterTest, AddChannelAutoProtobufVersion) {
 TEST(MultiTraceFileWriterAliasTest, AliasResolvesToCorrectType) {
     static_assert(std::is_same_v<osi3::MultiTraceFileWriter, osi3::MCAPTraceFileWriter>, "MultiTraceFileWriter must alias MCAPTraceFileWriter");
 }
+
+TEST_F(MCAPTraceFileWriterTest, AddRawChannel) {
+    ASSERT_TRUE(writer_.Open(test_file_));
+
+    const uint16_t channel_id = writer_.AddRawChannel(
+        "raw/lidar", "sensor_msgs/PointCloud2", "ros1msg", "", "ros1");
+    EXPECT_GT(channel_id, 0);
+}
+
+TEST_F(MCAPTraceFileWriterTest, WriteRawMessage) {
+    ASSERT_TRUE(writer_.Open(test_file_));
+
+    writer_.AddRawChannel("raw/data", "RawType", "raw", "", "raw");
+
+    const std::string payload = "raw_test_payload";
+    const auto* data = reinterpret_cast<const std::byte*>(payload.data());
+    EXPECT_TRUE(writer_.WriteRawMessage("raw/data", data, payload.size(), 1'000'000'000));
+
+    writer_.Close();
+    EXPECT_TRUE(std::filesystem::exists(test_file_));
+    EXPECT_GT(std::filesystem::file_size(test_file_), 0);
+}
+
+TEST_F(MCAPTraceFileWriterTest, WriteRawMessageUnregisteredTopic) {
+    ASSERT_TRUE(writer_.Open(test_file_));
+
+    const std::string payload = "data";
+    const auto* data = reinterpret_cast<const std::byte*>(payload.data());
+    EXPECT_FALSE(writer_.WriteRawMessage("nonexistent", data, payload.size(), 1));
+}
+
+TEST_F(MCAPTraceFileWriterTest, MixedOSIAndRawChannels) {
+    ASSERT_TRUE(writer_.Open(test_file_));
+    AddRequiredMetadata();
+
+    writer_.AddChannel("osi/gt", osi3::GroundTruth::descriptor());
+    writer_.AddRawChannel("raw/data", "CustomType", "raw", "", "raw");
+
+    osi3::GroundTruth gt;
+    gt.mutable_timestamp()->set_seconds(1);
+    EXPECT_TRUE(writer_.WriteMessage(gt, "osi/gt"));
+
+    const std::string payload = "raw_payload";
+    const auto* data = reinterpret_cast<const std::byte*>(payload.data());
+    EXPECT_TRUE(writer_.WriteRawMessage("raw/data", data, payload.size(), 1'000'000'000));
+
+    writer_.Close();
+
+    // Verify both channels exist
+    std::ifstream file(test_file_, std::ios::binary);
+    mcap::McapReader mcap_reader;
+    ASSERT_TRUE(mcap_reader.open(file).ok());
+    ASSERT_TRUE(mcap_reader.readSummary(mcap::ReadSummaryMethod::AllowFallbackScan).ok());
+    EXPECT_EQ(mcap_reader.channels().size(), 2);
+    mcap_reader.close();
+}

--- a/python/osi_utilities/tracefile/mcap_channel.py
+++ b/python/osi_utilities/tracefile/mcap_channel.py
@@ -117,3 +117,77 @@ class MCAPChannel:
         from osi_utilities.tracefile.writers.multi import prepare_required_file_metadata
 
         return prepare_required_file_metadata()
+
+    def add_raw_channel(
+        self,
+        topic: str,
+        schema_name: str,
+        schema_encoding: str,
+        schema_data: bytes,
+        message_encoding: str,
+        metadata: dict[str, str] | None = None,
+    ) -> int:
+        """Register a non-OSI channel with a custom schema on the external writer.
+
+        Args:
+            topic: Channel topic name.
+            schema_name: Name for the schema.
+            schema_encoding: Schema encoding (e.g. ``"ros1msg"``, ``"jsonschema"``).
+            schema_data: Serialized schema definition bytes (may be empty).
+            message_encoding: Message encoding (e.g. ``"ros1"``, ``"json"``).
+            metadata: Optional channel metadata dict.
+
+        Returns:
+            The channel ID.
+        """
+        if topic in self._channels:
+            raise RuntimeError(f"Channel '{topic}' already registered")
+
+        schema_id = self._mcap_writer.register_schema(
+            name=schema_name,
+            encoding=schema_encoding,
+            data=schema_data,
+        )
+        channel_meta = dict(metadata) if metadata else {}
+        channel_id = self._mcap_writer.register_channel(
+            topic=topic,
+            message_encoding=message_encoding,
+            schema_id=schema_id,
+            metadata=channel_meta,
+        )
+        self._channels[topic] = channel_id
+        return channel_id
+
+    def write_raw_message(
+        self,
+        topic: str,
+        data: bytes,
+        log_time: int,
+        publish_time: int | None = None,
+    ) -> bool:
+        """Write raw bytes to a registered channel (OSI or non-OSI).
+
+        Args:
+            topic: The channel topic.
+            data: Serialized message bytes.
+            log_time: Message timestamp in nanoseconds.
+            publish_time: Optional publish timestamp. Defaults to *log_time*.
+
+        Returns:
+            True on success.
+        """
+        if topic not in self._channels:
+            logger.error("Topic '%s' not registered", topic)
+            return False
+
+        try:
+            self._mcap_writer.add_message(
+                channel_id=self._channels[topic],
+                log_time=log_time,
+                data=data,
+                publish_time=publish_time if publish_time is not None else log_time,
+            )
+            return True
+        except (OSError,) as e:
+            logger.error("Failed to write raw message: %s", e)
+            return False

--- a/python/osi_utilities/tracefile/writers/multi.py
+++ b/python/osi_utilities/tracefile/writers/multi.py
@@ -318,3 +318,93 @@ class MultiTraceWriter(TraceWriter):
     @property
     def written_count(self) -> int:
         return self._written_count
+
+    def add_raw_channel(
+        self,
+        topic: str,
+        schema_name: str,
+        schema_encoding: str,
+        schema_data: bytes,
+        message_encoding: str,
+        metadata: dict[str, str] | None = None,
+    ) -> int:
+        """Register a non-OSI channel with a custom schema.
+
+        Use this to add channels that carry non-OSI data (e.g. raw ROS messages,
+        JSON telemetry) alongside OSI channels in the same MCAP file.
+
+        Args:
+            topic: Channel topic name.
+            schema_name: Name for the schema (e.g. ``"sensor_msgs/PointCloud2"``).
+            schema_encoding: Schema encoding (e.g. ``"ros1msg"``, ``"jsonschema"``).
+            schema_data: Serialized schema definition bytes (may be empty).
+            message_encoding: Message encoding (e.g. ``"ros1"``, ``"json"``).
+            metadata: Optional channel metadata dict.
+
+        Returns:
+            The channel ID.
+
+        Raises:
+            RuntimeError: If writer is not open or topic already exists.
+        """
+        if self._mcap_writer is None:
+            raise RuntimeError("Writer is not open")
+        if topic in self._active_channels:
+            raise RuntimeError(f"Channel with topic '{topic}' already exists")
+
+        schema_id = self._mcap_writer.register_schema(
+            name=schema_name,
+            encoding=schema_encoding,
+            data=schema_data,
+        )
+        channel_meta = dict(metadata) if metadata is not None else {}
+        channel_id = self._mcap_writer.register_channel(
+            topic=topic,
+            message_encoding=message_encoding,
+            schema_id=schema_id,
+            metadata=channel_meta,
+        )
+        self._active_channels[topic] = channel_id
+        self._channel_metadata[topic] = channel_meta
+        return channel_id
+
+    def write_raw_message(
+        self,
+        topic: str,
+        data: bytes,
+        log_time: int,
+        publish_time: int | None = None,
+    ) -> bool:
+        """Write raw bytes to a registered channel (OSI or non-OSI).
+
+        Args:
+            topic: The channel topic (must have been registered via
+                :meth:`add_channel` or :meth:`add_raw_channel`).
+            data: Serialized message bytes.
+            log_time: Message timestamp in nanoseconds.
+            publish_time: Optional publish timestamp in nanoseconds.
+                Defaults to *log_time*.
+
+        Returns:
+            True on success, False on failure.
+        """
+        if self._mcap_writer is None:
+            logger.error("Writer is not open")
+            return False
+
+        if topic not in self._active_channels:
+            logger.error("Topic '%s' not found. Available: %s", topic, list(self._active_channels.keys()))
+            return False
+
+        try:
+            self._mcap_writer.add_message(
+                channel_id=self._active_channels[topic],
+                log_time=log_time,
+                data=data,
+                publish_time=publish_time if publish_time is not None else log_time,
+            )
+            self._written_count += 1
+            return True
+        except (OSError, McapError) as e:
+            logger.error("Failed to write raw message to topic '%s': %s", topic, e)
+            return False

--- a/python/tests/test_extended.py
+++ b/python/tests/test_extended.py
@@ -176,6 +176,82 @@ class TestMCAPChannel:
         names = [f.name for f in fds.file]
         assert any("groundtruth" in n.lower() for n in names)
 
+    def test_add_raw_channel(self, tmp_dir: Path):
+        """Test registering a non-OSI raw channel via MCAPChannel."""
+        path = tmp_dir / "raw.mcap"
+        with open(path, "wb") as f:
+            writer = McapRawWriter(f)
+            writer.start(library="test")
+            channel = MCAPChannel(writer)
+            channel_id = channel.add_raw_channel(
+                "vehicle/status", "vehicle.Status", "jsonschema",
+                b'{"type": "object"}', "json",
+            )
+            assert isinstance(channel_id, int)
+            assert channel_id >= 0
+            writer.finish()
+
+    def test_add_raw_channel_duplicate_raises(self, tmp_dir: Path):
+        path = tmp_dir / "raw_dup.mcap"
+        with open(path, "wb") as f:
+            writer = McapRawWriter(f)
+            writer.start(library="test")
+            channel = MCAPChannel(writer)
+            channel.add_raw_channel("raw_topic", "T", "proto", b"", "proto")
+            with pytest.raises(RuntimeError, match="already registered"):
+                channel.add_raw_channel("raw_topic", "T", "proto", b"", "proto")
+            writer.finish()
+
+    def test_write_raw_message(self, tmp_dir: Path):
+        """Test writing raw bytes to a registered raw channel."""
+        path = tmp_dir / "raw_write.mcap"
+        with open(path, "wb") as f:
+            writer = McapRawWriter(f)
+            writer.start(library="test")
+            channel = MCAPChannel(writer)
+            channel.add_raw_channel("raw", "RawType", "raw", b"", "raw")
+            ok = channel.write_raw_message("raw", b"hello", log_time=5_000_000_000)
+            assert ok is True
+            writer.finish()
+
+        # Verify the message is in the file
+        from mcap.reader import make_reader
+        with open(path, "rb") as f:
+            reader = make_reader(f)
+            summary = reader.get_summary()
+            assert summary.statistics.message_count == 1
+
+    def test_write_raw_unregistered_topic(self, tmp_dir: Path):
+        path = tmp_dir / "raw_unreg.mcap"
+        with open(path, "wb") as f:
+            writer = McapRawWriter(f)
+            writer.start(library="test")
+            channel = MCAPChannel(writer)
+            assert not channel.write_raw_message("nope", b"data", log_time=1)
+            writer.finish()
+
+    def test_mixed_osi_and_raw_channels(self, tmp_dir: Path):
+        """Test mixing OSI and raw channels in the same MCAPChannel."""
+        path = tmp_dir / "mixed.mcap"
+        with open(path, "wb") as f:
+            writer = McapRawWriter(f)
+            writer.start(library="test")
+            channel = MCAPChannel(writer)
+            channel.add_channel("osi/gt", GroundTruth)
+            channel.add_raw_channel("raw/data", "CustomType", "raw", b"", "raw")
+
+            gt = _make_ground_truth(1)
+            assert channel.write_message(gt, "osi/gt")
+            assert channel.write_raw_message("raw/data", b"payload", log_time=1_000_000_000)
+            writer.finish()
+
+        from mcap.reader import make_reader
+        with open(path, "rb") as f:
+            reader = make_reader(f)
+            summary = reader.get_summary()
+            assert summary.statistics.message_count == 2
+            assert len(summary.channels) == 2
+
 
 # ===========================================================================
 # Reader error-path tests

--- a/python/tests/test_tracefile.py
+++ b/python/tests/test_tracefile.py
@@ -253,6 +253,65 @@ class TestMultiTraceFile:
             assert "ch1" in topics
             assert "ch2" in topics
 
+    def test_add_raw_channel(self, tmp_dir: Path):
+        """Test registering a non-OSI raw channel via MultiTraceWriter."""
+        path = tmp_dir / "raw.mcap"
+        with MultiTraceWriter() as writer:
+            assert writer.open(path)
+            channel_id = writer.add_raw_channel(
+                "vehicle/status", "vehicle.Status", "jsonschema",
+                b'{"type": "object"}', "json",
+            )
+            assert isinstance(channel_id, int)
+            ok = writer.write_raw_message("vehicle/status", b'{"speed": 50}', log_time=1_000_000_000)
+            assert ok
+            assert writer.written_count == 1
+
+        from mcap.reader import make_reader
+        with open(path, "rb") as f:
+            reader = make_reader(f)
+            summary = reader.get_summary()
+            assert summary.statistics.message_count == 1
+            topics = {c.topic for c in summary.channels.values()}
+            assert "vehicle/status" in topics
+
+    def test_add_raw_channel_duplicate_raises(self, tmp_dir: Path):
+        path = tmp_dir / "raw_dup.mcap"
+        with MultiTraceWriter() as writer:
+            assert writer.open(path)
+            writer.add_raw_channel("raw", "T", "raw", b"", "raw")
+            with pytest.raises(RuntimeError, match="already exists"):
+                writer.add_raw_channel("raw", "T", "raw", b"", "raw")
+
+    def test_write_raw_unregistered_topic(self, tmp_dir: Path):
+        path = tmp_dir / "raw_unreg.mcap"
+        with MultiTraceWriter() as writer:
+            assert writer.open(path)
+            assert not writer.write_raw_message("nope", b"data", log_time=1)
+
+    def test_mixed_osi_and_raw_channels(self, tmp_dir: Path):
+        """Test mixing OSI and raw channels in the same MultiTraceWriter."""
+        path = tmp_dir / "mixed.mcap"
+        with MultiTraceWriter() as writer:
+            assert writer.open(path)
+            writer.add_channel("osi/gt", GroundTruth)
+            writer.add_raw_channel("raw/data", "CustomType", "raw", b"", "raw")
+
+            gt = _make_ground_truth(1)
+            assert writer.write_message(gt, "osi/gt")
+            assert writer.write_raw_message("raw/data", b"payload", log_time=1_000_000_000)
+            assert writer.written_count == 2
+
+        from mcap.reader import make_reader
+        with open(path, "rb") as f:
+            reader = make_reader(f)
+            summary = reader.get_summary()
+            assert summary.statistics.message_count == 2
+            assert len(summary.channels) == 2
+            topics = {c.topic for c in summary.channels.values()}
+            assert "osi/gt" in topics
+            assert "raw/data" in topics
+
 
 # ===========================================================================
 # TXTH reader/writer


### PR DESCRIPTION
## Summary

Adds `add_raw_channel()` / `write_raw_message()` (Python) and `AddRawChannel()` / `WriteRawMessage()` (C++) to the high-level writer (`MultiTraceWriter` / `MCAPTraceFileWriter`) and the external-writer helper (`MCAPChannel` / `MCAPTraceFileChannel`).

## Motivation

The OSI trace file specification explicitly allows non-OSI message streams in MCAP files (§ net.asam.osi.trace). Real-world pipelines—such as converting ROS bags to OSI MCAP—need to embed raw sensor data (e.g. ROS `sensor_msgs/PointCloud2`) alongside OSI messages in a single MCAP container. Currently there is no API for this; users must break encapsulation via `GetMcapWriter()` (C++) or `_mcap_writer` (Python), bypassing internal bookkeeping.

These new methods keep the writer's internal state consistent (`_active_channels`, `_written_count`, close summary) while supporting arbitrary non-OSI channels.

## Changes

### Python
- **`MultiTraceWriter`**: `add_raw_channel(topic, schema_name, schema_encoding, schema_data, message_encoding, channel_metadata)` and `write_raw_message(topic, data, log_time, publish_time)`
- **`MCAPChannel`**: matching methods for the external-writer pattern (Part 2 in examples)
- **9 new tests** (4 for MultiTraceWriter + 5 for MCAPChannel) — all 161 tests pass

### C++
- **`MCAPTraceFileWriter`**: `AddRawChannel()` and `WriteRawMessage()` — delegates to channel
- **`MCAPTraceFileChannel`**: `AddRawChannel()` and `WriteRawMessage()` — registers schema/channel via `mcap::McapWriter`
- **10 new tests** (4 Writer + 6 Channel)

## Example Usage (Python)

```python
from osi_utilities.tracefile.writers import MultiTraceWriter
import osi3

with MultiTraceWriter("output.mcap") as writer:
    # OSI channel
    writer.add_channel("sensor/camera", osi3.SensorData)
    # Raw channel (e.g. original ROS message)
    writer.add_raw_channel("raw/pointcloud", "sensor_msgs/PointCloud2",
                           "ros1msg", schema_bytes, "ros1")

    writer.write_message(sensor_data, "sensor/camera")
    writer.write_raw_message("raw/pointcloud", raw_bytes, log_time_ns)
```

## Checklist
- [x] Python implementation + tests (all 161 pass)
- [x] C++ implementation + tests
- [x] Docstrings / Doxygen comments
- [x] No breaking changes to existing API
- [x] Follows conventional commits format

Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>