### PR TITLE
fix: write osi version to metadata

### DIFF
--- a/python/osi_utilities/tracefile/writers/multi.py
+++ b/python/osi_utilities/tracefile/writers/multi.py
@@ -44,14 +44,12 @@ _COMPRESSION_MAP: dict[str, CompressionType] = {
 }
 
 
-def _get_package_version() -> str:
-    """Get the package version from importlib.metadata, falling back to vcpkg.json."""
-    try:
-        from importlib.metadata import version
+def _get_osi_version() -> str:
+    """Get the current OSI interface version as 'major.minor.patch'."""
+    from osi3 import osi_version_pb2
 
-        return version("asam-osi-utilities")
-    except (ImportError, ModuleNotFoundError):
-        return "0.0.0"
+    version = osi_version_pb2.DESCRIPTOR.GetOptions().Extensions[osi_version_pb2.current_interface_version]
+    return f"{version.version_major}.{version.version_minor}.{version.version_patch}"
 
 
 def prepare_required_file_metadata() -> dict[str, str]:
@@ -60,7 +58,7 @@ def prepare_required_file_metadata() -> dict[str, str]:
     Returns a dict with required keys populated with placeholder/current values.
     """
     return {
-        "version": _get_package_version(),
+        "version": _get_osi_version(),
         "min_osi_version": "",
         "max_osi_version": "",
         "min_protobuf_version": google.protobuf.__version__,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2026, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
SPDX-License-Identifier: MPL-2.0
-->

## Related Issue

<!-- Use one: closes #123, fixes #123, refs #123 -->
None

## Summary

<!-- What changed and why? Keep this short and concrete. -->
The python asam-osi-utilities wrote its own version number (e.g. 0.4.0) into the mcap metadata which is intended for the actual OSI version.

## Validation

<!-- List what you ran locally (commands + outcome), e.g.:
- cmake --build --preset vcpkg --parallel
- ctest --test-dir build --output-on-failure
-->
I successfully ran the python tests locally and checked if the metadata now contains the correct version number.

## Checklist

<!-- Mark all that apply. Use N/A where appropriate and explain briefly in Summary or Validation. -->

- [ ] Unit tests added/updated for behavior changes (or N/A with reason).
- [ ] Documentation updated for user-visible/API changes (or N/A with reason).
- [x] Local checks pass (`pre-commit`, build, tests).
- [x] Reviewer(s) assigned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the `version` metadata written into trace files to be derived from the OSI interface version, improving accuracy and consistency of recorded trace version tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->