### PR TITLE
fix: correct net.asam.osi.trace version metadata and bump OSI to 3.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,12 @@ if (NOT OSIUTILITIES_DOCS_ONLY)
 
 endif ()
 
-# Trace file spec version implemented by this library (default matches OSI 3.8.0-rc1 tag used in submodule)
-set(OSI_TRACE_FILE_SPEC_VERSION "3.8.0-rc1" CACHE STRING "Trace file specification version implemented by OSIUtilities")
+# Trace file spec version implemented by this library (matches the released OSI 3.8.0 tag
+# pinned by the submodule). This is the OSI trace-file *format* version (net.asam.osi.trace
+# "version" field), NOT the linked OSI library version. Any pre-release/build suffix is
+# normalized to major.minor.patch when written into metadata. Keep in sync with the Python
+# OSI_TRACE_FILE_SPEC_VERSION (python/osi_utilities/tracefile/_config.py); see doc/releasing.md.
+set(OSI_TRACE_FILE_SPEC_VERSION "3.8.0" CACHE STRING "Trace file specification version implemented by OSIUtilities")
 if (OSI_VERSION AND NOT OSI_VERSION STREQUAL OSI_TRACE_FILE_SPEC_VERSION)
     message(STATUS "OSI version detected: ${OSI_VERSION} (trace file spec: ${OSI_TRACE_FILE_SPEC_VERSION})")
 endif ()

--- a/cpp/include/osi-utilities/tracefile/writer/MCAPTraceFileWriter.h
+++ b/cpp/include/osi-utilities/tracefile/writer/MCAPTraceFileWriter.h
@@ -8,7 +8,10 @@
 
 #include <google/protobuf/message.h>
 
+#include <array>
+#include <cstdint>
 #include <mcap/mcap.hpp>
+#include <optional>
 
 #include "osi-utilities/tracefile/Writer.h"
 #include "osi-utilities/tracefile/writer/MCAPTraceFileChannel.h"
@@ -132,11 +135,22 @@ class MCAPTraceFileWriter final : public osi3::TraceFileWriter {
     mcap::McapWriter* GetMcapWriter() { return &mcap_writer_; }
 
    private:
+    /** @brief Buffers the auto-generated net.asam.osi.trace metadata if none is pending yet */
+    void EnsurePendingMetadata();
+    /** @brief Updates the running min/max embedded OSI InterfaceVersion from a written message */
+    void TrackOsiVersion(const google::protobuf::Message& message);
+    /** @brief Writes the buffered net.asam.osi.trace record, filling min/max_osi_version */
+    void FinalizeFileMetadata();
+
     std::ofstream trace_file_;                         /**< Trace file stream */
     mcap::McapWriter mcap_writer_;                     /**< MCAP writer instance */
     mcap::McapWriterOptions mcap_options_{"protobuf"}; /**< MCAP writer configuration */
     MCAPTraceFileChannel channel_{mcap_writer_};       /**< Delegated channel/schema management */
     bool required_metadata_added_ = false;             /**< Flag to track if required metadata has been added */
+    /** @brief Buffered net.asam.osi.trace record, written at Close() once OSI versions are known */
+    std::optional<mcap::Metadata> pending_osi_metadata_;
+    std::optional<std::array<uint32_t, 3>> osi_version_min_; /**< Min embedded OSI version seen */
+    std::optional<std::array<uint32_t, 3>> osi_version_max_; /**< Max embedded OSI version seen */
 };
 
 /** @brief Alias for MCAPTraceFileWriter matching Python naming convention */

--- a/cpp/src/tracefile/writer/MCAPTraceFileWriter.cpp
+++ b/cpp/src/tracefile/writer/MCAPTraceFileWriter.cpp
@@ -5,6 +5,7 @@
 
 #include "osi-utilities/tracefile/writer/MCAPTraceFileWriter.h"
 
+#include "MCAPWriterUtils.h"
 #include "osi_groundtruth.pb.h"
 #include "osi_hostvehicledata.pb.h"
 #include "osi_motionrequest.pb.h"
@@ -49,14 +50,14 @@ auto MCAPTraceFileWriter::WriteMessage(const google::protobuf::Message& message,
         std::cerr << "ERROR: cannot write message, file is not open\n";
         return false;
     }
-    // Auto-add required metadata on first write if not set
-    if (!required_metadata_added_) {
-        if (!AddFileMetadata(PrepareRequiredFileMetadata())) {
-            std::cerr << "ERROR: failed to auto-add required metadata\n";
-            return false;
-        }
+    // The net.asam.osi.trace record is buffered now and written at Close() with
+    // data-accurate min/max_osi_version derived from the messages actually written.
+    EnsurePendingMetadata();
+    if (!channel_.WriteMessage(message, topic)) {
+        return false;
     }
-    return channel_.WriteMessage(message, topic);
+    TrackOsiVersion(message);
+    return true;
 }
 
 template <typename T>
@@ -65,16 +66,17 @@ auto MCAPTraceFileWriter::WriteMessage(const T& top_level_message, const std::st
         std::cerr << "ERROR: cannot write message, file is not open\n";
         return false;
     }
-    if (!required_metadata_added_) {
-        std::cerr << "ERROR: cannot write message, required metadata (according to the OSI specification) was not set in advance\n";
+    EnsurePendingMetadata();
+    if (!channel_.WriteMessage(top_level_message, topic)) {
         return false;
     }
-    return channel_.WriteMessage(top_level_message, topic);
+    TrackOsiVersion(top_level_message);
+    return true;
 }
 
 auto MCAPTraceFileWriter::AddFileMetadata(const mcap::Metadata& metadata) -> bool {
-    // check if the provided metadata contains the required metadata by the OSI specification
-    // to allow writing messages to the trace file
+    // The net.asam.osi.trace record is buffered and written at Close(), so that
+    // min/max_osi_version can be filled from the OSI version of the messages written.
     if (metadata.name == "net.asam.osi.trace") {
         if (required_metadata_added_) {
             std::cerr << "ERROR: cannot add net.asam.osi.trace metadata record, it was already added.\n";
@@ -88,10 +90,12 @@ auto MCAPTraceFileWriter::AddFileMetadata(const mcap::Metadata& metadata) -> boo
                 return false;
             }
         }
+        pending_osi_metadata_ = metadata;
         required_metadata_added_ = true;
+        return true;
     }
 
-    // add metadata to file
+    // All other metadata records are written immediately.
     if (const auto status = mcap_writer_.write(metadata); status.code != mcap::StatusCode::Success) {
         std::cerr << "ERROR: Failed to write metadata with name " << metadata.name << "\n" << status.message;
         return false;
@@ -107,8 +111,64 @@ auto MCAPTraceFileWriter::AddFileMetadata(const std::string& name, const std::un
 }
 
 void MCAPTraceFileWriter::Close() {
+    FinalizeFileMetadata();
     mcap_writer_.close();
     trace_file_.close();
+}
+
+void MCAPTraceFileWriter::EnsurePendingMetadata() {
+    if (!pending_osi_metadata_.has_value()) {
+        pending_osi_metadata_ = PrepareRequiredFileMetadata();
+        required_metadata_added_ = true;
+    }
+}
+
+void MCAPTraceFileWriter::TrackOsiVersion(const google::protobuf::Message& message) {
+    const auto version = mcap_utils::GetMessageOsiVersion(message);
+    if (!version.has_value()) {
+        return;
+    }
+    if (!osi_version_min_.has_value() || *version < *osi_version_min_) {
+        osi_version_min_ = version;
+    }
+    if (!osi_version_max_.has_value() || *version > *osi_version_max_) {
+        osi_version_max_ = version;
+    }
+}
+
+void MCAPTraceFileWriter::FinalizeFileMetadata() {
+    if (!pending_osi_metadata_.has_value()) {
+        return;  // nothing written and no metadata added: no record to finalize
+    }
+    auto& metadata = *pending_osi_metadata_;
+
+    std::string min_version = osi_version_min_.has_value() ? mcap_utils::OsiVersionToString(*osi_version_min_) : std::string{};
+    std::string max_version = osi_version_max_.has_value() ? mcap_utils::OsiVersionToString(*osi_version_max_) : std::string{};
+    // Fall back to the linked OSI library version when no written message carried one.
+    if (min_version.empty() || max_version.empty()) {
+        const auto fallback_version = mcap_utils::GetOsiVersionString();
+        if (min_version.empty()) {
+            min_version = fallback_version;
+        }
+        if (max_version.empty()) {
+            max_version = fallback_version;
+        }
+    }
+    // Only fill fields the caller left empty; respect explicit user-provided values.
+    if (const auto it = metadata.metadata.find("min_osi_version"); it == metadata.metadata.end() || it->second.empty()) {
+        metadata.metadata["min_osi_version"] = min_version;
+    }
+    if (const auto it = metadata.metadata.find("max_osi_version"); it == metadata.metadata.end() || it->second.empty()) {
+        metadata.metadata["max_osi_version"] = max_version;
+    }
+
+    if (const auto status = mcap_writer_.write(metadata); status.code != mcap::StatusCode::Success) {
+        std::cerr << "ERROR: Failed to write net.asam.osi.trace metadata\n" << status.message;
+    }
+    pending_osi_metadata_.reset();
+    osi_version_min_.reset();
+    osi_version_max_.reset();
+    required_metadata_added_ = false;
 }
 
 auto MCAPTraceFileWriter::PrepareRequiredFileMetadata() -> mcap::Metadata { return MCAPTraceFileChannel::PrepareRequiredFileMetadata(); }

--- a/cpp/src/tracefile/writer/MCAPTraceFileWriter.cpp
+++ b/cpp/src/tracefile/writer/MCAPTraceFileWriter.cpp
@@ -50,12 +50,12 @@ auto MCAPTraceFileWriter::WriteMessage(const google::protobuf::Message& message,
         std::cerr << "ERROR: cannot write message, file is not open\n";
         return false;
     }
-    // The net.asam.osi.trace record is buffered now and written at Close() with
-    // data-accurate min/max_osi_version derived from the messages actually written.
-    EnsurePendingMetadata();
     if (!channel_.WriteMessage(message, topic)) {
         return false;
     }
+    // Buffer the net.asam.osi.trace record only after a message was actually written; it is
+    // emitted at Close() with data-accurate min/max_osi_version from the messages written.
+    EnsurePendingMetadata();
     TrackOsiVersion(message);
     return true;
 }
@@ -66,10 +66,12 @@ auto MCAPTraceFileWriter::WriteMessage(const T& top_level_message, const std::st
         std::cerr << "ERROR: cannot write message, file is not open\n";
         return false;
     }
-    EnsurePendingMetadata();
     if (!channel_.WriteMessage(top_level_message, topic)) {
         return false;
     }
+    // Buffer the net.asam.osi.trace record only after a message was actually written; it is
+    // emitted at Close() with data-accurate min/max_osi_version from the messages written.
+    EnsurePendingMetadata();
     TrackOsiVersion(top_level_message);
     return true;
 }
@@ -91,6 +93,9 @@ auto MCAPTraceFileWriter::AddFileMetadata(const mcap::Metadata& metadata) -> boo
             }
         }
         pending_osi_metadata_ = metadata;
+        // "version" is the OSI trace-file format version and must be major.minor.patch; normalize
+        // any caller-supplied pre-release/build suffix (e.g. "3.8.0-rc1" -> "3.8.0") for conformance.
+        pending_osi_metadata_->metadata["version"] = mcap_utils::NormalizeOsiVersionString(pending_osi_metadata_->metadata["version"]);
         required_metadata_added_ = true;
         return true;
     }

--- a/cpp/src/tracefile/writer/MCAPWriterUtils.h
+++ b/cpp/src/tracefile/writer/MCAPWriterUtils.h
@@ -8,11 +8,16 @@
 
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/message.h>
 #include <google/protobuf/stubs/common.h>
 
+#include <array>
 #include <chrono>
+#include <cstdint>
 #include <iomanip>
 #include <mcap/mcap.hpp>
+#include <optional>
+#include <regex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -77,6 +82,71 @@ inline auto GetOsiVersionString() -> std::string {
 inline auto GetProtobufVersionString() -> std::string { return google::protobuf::internal::VersionString(GOOGLE_PROTOBUF_VERSION); }
 
 /**
+ * @brief Normalizes a version string to a strict ``major.minor.patch`` core.
+ *
+ * The OSI trace metadata version fields must be ``major.minor.patch``; any
+ * pre-release/build suffix (e.g. ``"3.8.0-rc1"`` -> ``"3.8.0"``) is stripped so the emitted
+ * value stays spec-conformant across release-candidate cycles. The input is returned
+ * unchanged if it does not start with a numeric ``major.minor.patch``.
+ *
+ * @param version The version string to normalize
+ * @return The ``major.minor.patch`` core, or the original string if it has no numeric core
+ */
+inline auto NormalizeOsiVersionString(const std::string& version) -> std::string {
+    static const std::regex kVersionCoreRegex(R"(^\s*(\d+)\.(\d+)\.(\d+))");
+    std::smatch match;
+    if (std::regex_search(version, match, kVersionCoreRegex)) {
+        return match[1].str() + "." + match[2].str() + "." + match[3].str();
+    }
+    return version;
+}
+
+/**
+ * @brief Formats an OSI version triple as a ``major.minor.patch`` string.
+ */
+inline auto OsiVersionToString(const std::array<uint32_t, 3>& version) -> std::string {
+    return std::to_string(version[0]) + "." + std::to_string(version[1]) + "." + std::to_string(version[2]);
+}
+
+/**
+ * @brief Extracts the embedded OSI ``InterfaceVersion`` from a top-level OSI message.
+ *
+ * Uses protobuf reflection to read the singular ``version`` message field that all OSI
+ * top-level messages carry. Returns ``std::nullopt`` when the message has no such field,
+ * it is unset, or it is the meaningless all-zero default (which OSI itself documents as an
+ * unset/legacy version).
+ *
+ * @param message The top-level OSI protobuf message
+ * @return ``{major, minor, patch}`` if a usable version is present, otherwise ``std::nullopt``
+ */
+inline auto GetMessageOsiVersion(const google::protobuf::Message& message) -> std::optional<std::array<uint32_t, 3>> {
+    const auto* descriptor = message.GetDescriptor();
+    const auto* version_field = descriptor->FindFieldByName("version");
+    if (version_field == nullptr || version_field->is_repeated() || version_field->cpp_type() != google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+        return std::nullopt;
+    }
+    const auto* reflection = message.GetReflection();
+    if (!reflection->HasField(message, version_field)) {
+        return std::nullopt;
+    }
+    const auto& version_message = reflection->GetMessage(message, version_field);
+    const auto* version_descriptor = version_message.GetDescriptor();
+    const auto* version_reflection = version_message.GetReflection();
+    const auto read_component = [&](const char* name) -> uint32_t {
+        const auto* component_field = version_descriptor->FindFieldByName(name);
+        if (component_field == nullptr || component_field->cpp_type() != google::protobuf::FieldDescriptor::CPPTYPE_UINT32) {
+            return 0U;
+        }
+        return version_reflection->GetUInt32(version_message, component_field);
+    };
+    const std::array<uint32_t, 3> triple = {read_component("version_major"), read_component("version_minor"), read_component("version_patch")};
+    if (triple[0] == 0U && triple[1] == 0U && triple[2] == 0U) {
+        return std::nullopt;
+    }
+    return triple;
+}
+
+/**
  * @brief Helper function that returns the current time as a formatted string
  * @return Current timestamp as string in ISO 8601 format with Z suffix
  *
@@ -114,10 +184,14 @@ inline auto PrepareRequiredFileMetadata(const std::string& trace_file_spec_versi
     mcap::Metadata metadata;
     metadata.name = "net.asam.osi.trace";
 
-    const auto osi_version_string = GetOsiVersionString();
-    metadata.metadata["version"] = trace_file_spec_version;
-    metadata.metadata["min_osi_version"] = osi_version_string;
-    metadata.metadata["max_osi_version"] = osi_version_string;
+    // "version" is the OSI trace-file *format* version (normalized to major.minor.patch).
+    // min/max_osi_version are intentionally left empty here: MCAPTraceFileWriter fills them
+    // at Close() from the embedded InterfaceVersion of the messages actually written
+    // (falling back to the linked OSI library version). Callers using an external writer
+    // may populate them themselves.
+    metadata.metadata["version"] = NormalizeOsiVersionString(trace_file_spec_version);
+    metadata.metadata["min_osi_version"] = "";
+    metadata.metadata["max_osi_version"] = "";
     metadata.metadata["min_protobuf_version"] = GetProtobufVersionString();
     metadata.metadata["max_protobuf_version"] = GetProtobufVersionString();
 

--- a/cpp/tests/src/tracefile/writer/MCAPTraceFileWriter_test.cpp
+++ b/cpp/tests/src/tracefile/writer/MCAPTraceFileWriter_test.cpp
@@ -13,8 +13,11 @@
 #include <regex>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 
+#include "../../../../src/tracefile/writer/MCAPWriterUtils.h"
 #include "../../TestUtilities.h"
+#include "osi-utilities/tracefile/reader/MCAPTraceFileReader.h"
 #include "osi_groundtruth.pb.h"
 #include "osi_sensordata.pb.h"
 
@@ -87,7 +90,7 @@ TEST_F(MCAPTraceFileWriterTest, WriteMessage) {
     EXPECT_TRUE(writer_.WriteMessage(ground_truth, topic));
 }
 
-TEST_F(MCAPTraceFileWriterTest, TryWriteWithoutReqMetaData) {
+TEST_F(MCAPTraceFileWriterTest, WriteWithoutExplicitMetadataSucceeds) {
     ASSERT_TRUE(writer_.Open(test_file_));
     // Create test message
     osi3::GroundTruth ground_truth;
@@ -98,8 +101,11 @@ TEST_F(MCAPTraceFileWriterTest, TryWriteWithoutReqMetaData) {
     const std::string topic = "/ground_truth";
     writer_.AddChannel(topic, osi3::GroundTruth::descriptor(), {});
 
-    // Try to write message but fail
-    EXPECT_FALSE(writer_.WriteMessage(ground_truth, topic));
+    // Writing without explicitly adding metadata now succeeds: the required
+    // net.asam.osi.trace record is auto-generated and finalized at Close().
+    EXPECT_TRUE(writer_.WriteMessage(ground_truth, topic));
+    writer_.Close();
+    EXPECT_GT(std::filesystem::file_size(test_file_), 0);
 }
 
 TEST_F(MCAPTraceFileWriterTest, SetMetadata) {
@@ -153,9 +159,15 @@ TEST_F(MCAPTraceFileWriterTest, GetCurrentTimeAsString) {
 TEST_F(MCAPTraceFileWriterTest, PrepareRequiredFileMetadata) {
     const auto metadata = osi3::MCAPTraceFileWriter::PrepareRequiredFileMetadata();
     EXPECT_EQ(metadata.name, "net.asam.osi.trace");
-    EXPECT_NE(metadata.metadata.find("version"), metadata.metadata.end());
-    EXPECT_NE(metadata.metadata.find("min_osi_version"), metadata.metadata.end());
-    EXPECT_NE(metadata.metadata.find("max_osi_version"), metadata.metadata.end());
+    ASSERT_NE(metadata.metadata.find("version"), metadata.metadata.end());
+    // version is the normalized OSI trace-file FORMAT version (major.minor.patch)
+    EXPECT_EQ(metadata.metadata.at("version"), osi3::mcap_utils::NormalizeOsiVersionString(OSI_TRACE_FILE_SPEC_VERSION));
+    EXPECT_TRUE(std::regex_match(metadata.metadata.at("version"), std::regex(R"(\d+\.\d+\.\d+)")));
+    // min/max_osi_version are placeholders here; the writer fills them at Close()
+    ASSERT_NE(metadata.metadata.find("min_osi_version"), metadata.metadata.end());
+    ASSERT_NE(metadata.metadata.find("max_osi_version"), metadata.metadata.end());
+    EXPECT_TRUE(metadata.metadata.at("min_osi_version").empty());
+    EXPECT_TRUE(metadata.metadata.at("max_osi_version").empty());
     EXPECT_NE(metadata.metadata.find("min_protobuf_version"), metadata.metadata.end());
     EXPECT_NE(metadata.metadata.find("max_protobuf_version"), metadata.metadata.end());
 }
@@ -226,12 +238,13 @@ TEST_F(MCAPTraceFileWriterTest, WriteMessageFailedWrite) {
     EXPECT_FALSE(writer_.WriteMessage(ground_truth, topic));
 }
 
-TEST_F(MCAPTraceFileWriterTest, WriteMetadataFailedWrite) {
+TEST_F(MCAPTraceFileWriterTest, AddNonOsiMetadataFailedWrite) {
     ASSERT_TRUE(writer_.Open(test_file_));
-    // Terminate file to force write failure
+    // Terminate the writer so the immediate write of a non-OSI metadata record fails.
+    // (The net.asam.osi.trace record is buffered and only written at Close().)
     writer_.GetMcapWriter()->terminate();
-
-    EXPECT_THROW(AddRequiredMetadata(), std::runtime_error);
+    const std::unordered_map<std::string, std::string> entries{{"key", "value"}};
+    EXPECT_FALSE(writer_.AddFileMetadata("custom.metadata", entries));
 }
 
 TEST_F(MCAPTraceFileWriterTest, AddChannelTopicExistsWithDifferentType) {
@@ -337,6 +350,119 @@ TEST_F(MCAPTraceFileWriterTest, AddChannelAutoProtobufVersion) {
     }
     EXPECT_TRUE(found_protobuf_version);
     mcap_reader.close();
+}
+
+// ============================================================================
+// net.asam.osi.trace metadata versioning (version / min_osi_version / max_osi_version)
+// ============================================================================
+
+namespace {
+
+// Reads back the net.asam.osi.trace metadata map from a written file via the project reader.
+auto ReadOsiTraceMetadata(const std::filesystem::path& path) -> std::unordered_map<std::string, std::string> {
+    osi3::MCAPTraceFileReader reader;
+    EXPECT_TRUE(reader.Open(path));
+    for (const auto& [name, kv_map] : reader.GetFileMetadata()) {
+        if (name == "net.asam.osi.trace") {
+            return kv_map;
+        }
+    }
+    return {};
+}
+
+void SetOsiVersion(osi3::GroundTruth& message, uint32_t major, uint32_t minor, uint32_t patch) {
+    message.mutable_version()->set_version_major(major);
+    message.mutable_version()->set_version_minor(minor);
+    message.mutable_version()->set_version_patch(patch);
+}
+
+}  // namespace
+
+TEST_F(MCAPTraceFileWriterTest, MetadataVersionIsNormalizedFormatVersion) {
+    ASSERT_TRUE(writer_.Open(test_file_));
+    osi3::GroundTruth ground_truth;
+    ground_truth.mutable_timestamp()->set_seconds(1);
+    SetOsiVersion(ground_truth, 3, 5, 2);
+    writer_.AddChannel("gt", osi3::GroundTruth::descriptor());
+    ASSERT_TRUE(writer_.WriteMessage(ground_truth, "gt"));
+    writer_.Close();
+
+    const auto metadata = ReadOsiTraceMetadata(test_file_);
+    ASSERT_FALSE(metadata.empty());
+    // "version" is the trace-file FORMAT version, independent of the data's OSI version.
+    EXPECT_EQ(metadata.at("version"), osi3::mcap_utils::NormalizeOsiVersionString(OSI_TRACE_FILE_SPEC_VERSION));
+    EXPECT_TRUE(std::regex_match(metadata.at("version"), std::regex(R"(\d+\.\d+\.\d+)")));
+}
+
+TEST_F(MCAPTraceFileWriterTest, MinMaxOsiVersionFromWrittenMessages) {
+    ASSERT_TRUE(writer_.Open(test_file_));
+    writer_.AddChannel("gt", osi3::GroundTruth::descriptor());
+
+    osi3::GroundTruth low;
+    low.mutable_timestamp()->set_seconds(1);
+    SetOsiVersion(low, 3, 5, 2);
+    ASSERT_TRUE(writer_.WriteMessage(low, "gt"));
+
+    osi3::GroundTruth high;
+    high.mutable_timestamp()->set_seconds(2);
+    SetOsiVersion(high, 3, 7, 0);
+    ASSERT_TRUE(writer_.WriteMessage(high, "gt"));
+
+    // A message without a version must not influence min/max.
+    osi3::GroundTruth no_version;
+    no_version.mutable_timestamp()->set_seconds(3);
+    ASSERT_TRUE(writer_.WriteMessage(no_version, "gt"));
+
+    writer_.Close();
+
+    const auto metadata = ReadOsiTraceMetadata(test_file_);
+    ASSERT_FALSE(metadata.empty());
+    EXPECT_EQ(metadata.at("min_osi_version"), "3.5.2");
+    EXPECT_EQ(metadata.at("max_osi_version"), "3.7.0");
+}
+
+TEST_F(MCAPTraceFileWriterTest, MinMaxOsiVersionFallsBackToLibraryVersion) {
+    ASSERT_TRUE(writer_.Open(test_file_));
+    writer_.AddChannel("gt", osi3::GroundTruth::descriptor());
+    osi3::GroundTruth no_version;
+    no_version.mutable_timestamp()->set_seconds(1);
+    ASSERT_TRUE(writer_.WriteMessage(no_version, "gt"));
+    writer_.Close();
+
+    const auto metadata = ReadOsiTraceMetadata(test_file_);
+    ASSERT_FALSE(metadata.empty());
+    const auto library_version = osi3::mcap_utils::GetOsiVersionString();
+    EXPECT_EQ(metadata.at("min_osi_version"), library_version);
+    EXPECT_EQ(metadata.at("max_osi_version"), library_version);
+}
+
+TEST_F(MCAPTraceFileWriterTest, UserSuppliedMinMaxOsiVersionPreserved) {
+    ASSERT_TRUE(writer_.Open(test_file_));
+    auto metadata = osi3::MCAPTraceFileWriter::PrepareRequiredFileMetadata();
+    metadata.metadata["min_osi_version"] = "3.0.0";
+    metadata.metadata["max_osi_version"] = "3.0.0";
+    ASSERT_TRUE(writer_.AddFileMetadata(metadata));
+
+    writer_.AddChannel("gt", osi3::GroundTruth::descriptor());
+    osi3::GroundTruth ground_truth;
+    ground_truth.mutable_timestamp()->set_seconds(1);
+    SetOsiVersion(ground_truth, 3, 6, 1);
+    ASSERT_TRUE(writer_.WriteMessage(ground_truth, "gt"));
+    writer_.Close();
+
+    const auto written = ReadOsiTraceMetadata(test_file_);
+    ASSERT_FALSE(written.empty());
+    EXPECT_EQ(written.at("min_osi_version"), "3.0.0");
+    EXPECT_EQ(written.at("max_osi_version"), "3.0.0");
+}
+
+TEST_F(MCAPTraceFileWriterTest, NormalizeOsiVersionStripsPreReleaseSuffix) {
+    using osi3::mcap_utils::NormalizeOsiVersionString;
+    EXPECT_EQ(NormalizeOsiVersionString("3.8.0"), "3.8.0");
+    EXPECT_EQ(NormalizeOsiVersionString("3.8.0-rc1"), "3.8.0");
+    EXPECT_EQ(NormalizeOsiVersionString("3.9.0-alpha.2+build.7"), "3.9.0");
+    EXPECT_EQ(NormalizeOsiVersionString("10.20.30"), "10.20.30");
+    EXPECT_EQ(NormalizeOsiVersionString("not-a-version"), "not-a-version");
 }
 
 TEST(MultiTraceFileWriterAliasTest, AliasResolvesToCorrectType) {

--- a/cpp/tests/src/tracefile/writer/MCAPTraceFileWriter_test.cpp
+++ b/cpp/tests/src/tracefile/writer/MCAPTraceFileWriter_test.cpp
@@ -465,6 +465,46 @@ TEST_F(MCAPTraceFileWriterTest, NormalizeOsiVersionStripsPreReleaseSuffix) {
     EXPECT_EQ(NormalizeOsiVersionString("not-a-version"), "not-a-version");
 }
 
+TEST_F(MCAPTraceFileWriterTest, ExplicitMetadataVersionIsNormalized) {
+    ASSERT_TRUE(writer_.Open(test_file_));
+    auto metadata = osi3::MCAPTraceFileWriter::PrepareRequiredFileMetadata();
+    // A caller-supplied pre-release version must be normalized to major.minor.patch.
+    metadata.metadata["version"] = "3.8.0-rc1";
+    ASSERT_TRUE(writer_.AddFileMetadata(metadata));
+
+    writer_.AddChannel("gt", osi3::GroundTruth::descriptor());
+    osi3::GroundTruth ground_truth;
+    ground_truth.mutable_timestamp()->set_seconds(1);
+    SetOsiVersion(ground_truth, 3, 6, 1);
+    ASSERT_TRUE(writer_.WriteMessage(ground_truth, "gt"));
+    writer_.Close();
+
+    const auto written = ReadOsiTraceMetadata(test_file_);
+    ASSERT_FALSE(written.empty());
+    EXPECT_EQ(written.at("version"), "3.8.0");
+}
+
+TEST_F(MCAPTraceFileWriterTest, FailedWriteDoesNotReserveOsiTraceMetadata) {
+    ASSERT_TRUE(writer_.Open(test_file_));
+
+    osi3::GroundTruth ground_truth;
+    ground_truth.mutable_timestamp()->set_seconds(1);
+    // Writing to an unregistered topic fails; this must not reserve the net.asam.osi.trace
+    // record, so an explicit AddFileMetadata() afterwards still succeeds and is honored.
+    EXPECT_FALSE(writer_.WriteMessage(ground_truth, "/unregistered"));
+
+    auto metadata = osi3::MCAPTraceFileWriter::PrepareRequiredFileMetadata();
+    metadata.metadata["min_osi_version"] = "3.1.0";
+    metadata.metadata["max_osi_version"] = "3.1.0";
+    EXPECT_TRUE(writer_.AddFileMetadata(metadata));
+    writer_.Close();
+
+    const auto written = ReadOsiTraceMetadata(test_file_);
+    ASSERT_FALSE(written.empty());
+    EXPECT_EQ(written.at("min_osi_version"), "3.1.0");
+    EXPECT_EQ(written.at("max_osi_version"), "3.1.0");
+}
+
 TEST(MultiTraceFileWriterAliasTest, AliasResolvesToCorrectType) {
     static_assert(std::is_same_v<osi3::MultiTraceFileWriter, osi3::MCAPTraceFileWriter>, "MultiTraceFileWriter must alias MCAPTraceFileWriter");
 }

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -43,11 +43,17 @@ OSI defines a specialization of the MCAP format with additional constraints. See
 
 The `net.asam.osi.trace` metadata record must include:
 
-- `version` - OSI release version (e.g., `3.8.0`)
-- `min_osi_version` - Minimum OSI schema version used
-- `max_osi_version` - Maximum OSI schema version used
+- `version` - OSI **trace-file format** version the file conforms to (e.g. `3.8.0`). This is
+  *not* the OSI schema version of the data; it is normalized to `major.minor.patch`.
+- `min_osi_version` - Minimum OSI schema version used in the channels' messages
+- `max_osi_version` - Maximum OSI schema version used in the channels' messages
 - `min_protobuf_version` - Minimum protobuf version used
 - `max_protobuf_version` - Maximum protobuf version used
+
+The writers fill `min_osi_version` / `max_osi_version` automatically from the embedded
+`InterfaceVersion` of the messages actually written (the record is finalized when the file is
+closed), falling back to the linked OSI library version when no message carries one. Any
+value you supply explicitly is preserved.
 
 ### Single-Channel Binary
 

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -31,6 +31,19 @@ The canonical version is stored in:
 
 - `vcpkg.json` → `version-string` field
 
+### OSI trace-file format version
+
+The OSI trace-file *format* version written into `net.asam.osi.trace`'s `version` field is a
+separate constant from the library/package version. It must be kept in sync across both
+language bindings:
+
+- C++: `OSI_TRACE_FILE_SPEC_VERSION` (CMake cache variable in the top-level `CMakeLists.txt`)
+- Python: `OSI_TRACE_FILE_SPEC_VERSION` in `python/osi_utilities/tracefile/_config.py`
+
+Both default to the released OSI version pinned by the submodule (currently `3.8.0`). Any
+pre-release/build suffix (e.g. `3.9.0-rc1`) is normalized to `major.minor.patch` when emitted
+into metadata, so update the constant when bumping the implemented trace-file format version.
+
 ## Release Workflow
 
 ### 1. Prepare the Release

--- a/python/osi_utilities/tracefile/_config.py
+++ b/python/osi_utilities/tracefile/_config.py
@@ -26,6 +26,15 @@ NANOSECONDS_PER_SECOND: int = 1_000_000_000
 # Text format constants
 TXTH_READ_BUFFER_RESERVE_SIZE: int = 4096
 
+# OSI trace-file *format* specification version implemented by this library.
+# This is the value of the net.asam.osi.trace ``version`` metadata field: per the OSI
+# spec it is the version of the OSI trace-file format the file conforms to, NOT the OSI
+# schema version of the data (that goes in min/max_osi_version) nor the Python package
+# version. Keep in sync with the C++ ``OSI_TRACE_FILE_SPEC_VERSION`` (CMakeLists.txt).
+# See doc/releasing.md. Any pre-release/build suffix is normalized to major.minor.patch
+# when emitted into metadata.
+OSI_TRACE_FILE_SPEC_VERSION: str = "3.8.0"
+
 # OSI MCAP metadata keys
 OSI_TRACE_METADATA_NAME: str = "net.asam.osi.trace"
 OSI_CHANNEL_OSI_VERSION_KEY: str = "net.asam.osi.trace.channel.osi_version"

--- a/python/osi_utilities/tracefile/writers/multi.py
+++ b/python/osi_utilities/tracefile/writers/multi.py
@@ -233,6 +233,12 @@ class MultiTraceWriter(TraceWriter):
             # Defer writing the net.asam.osi.trace record until close(): min/max_osi_version
             # are filled from the embedded InterfaceVersion of the messages actually written.
             self._pending_file_metadata = dict(file_metadata)
+            # "version" is the OSI trace-file format version and must be major.minor.patch;
+            # normalize any caller-supplied pre-release/build suffix (e.g. "3.8.0-rc1" -> "3.8.0").
+            if self._pending_file_metadata.get("version"):
+                self._pending_file_metadata["version"] = _normalize_osi_version_string(
+                    self._pending_file_metadata["version"]
+                )
             self._osi_version_min = None
             self._osi_version_max = None
 

--- a/python/osi_utilities/tracefile/writers/multi.py
+++ b/python/osi_utilities/tracefile/writers/multi.py
@@ -10,6 +10,7 @@ schema registration via FileDescriptorSet, and OSI metadata validation.
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO
@@ -28,6 +29,7 @@ from osi_utilities.tracefile._config import (
     MIN_CHUNK_SIZE,
     OSI_CHANNEL_RECOMMENDED_METADATA_KEYS,
     OSI_CHANNEL_REQUIRED_METADATA_KEYS,
+    OSI_TRACE_FILE_SPEC_VERSION,
     OSI_TRACE_METADATA_NAME,
     OSI_TRACE_RECOMMENDED_METADATA_KEYS,
     OSI_TRACE_REQUIRED_METADATA_KEYS,
@@ -44,23 +46,66 @@ _COMPRESSION_MAP: dict[str, CompressionType] = {
 }
 
 
-def _get_package_version() -> str:
-    """Get the package version from importlib.metadata, falling back to vcpkg.json."""
-    try:
-        from importlib.metadata import version
+_SEMVER_CORE_RE = re.compile(r"^\s*(\d+)\.(\d+)\.(\d+)")
 
-        return version("asam-osi-utilities")
+
+def _normalize_osi_version_string(version: str) -> str:
+    """Return the strict ``major.minor.patch`` core of a version string.
+
+    The OSI trace metadata version fields must be ``major.minor.patch``; any
+    pre-release/build suffix (e.g. ``"3.8.0-rc1"`` -> ``"3.8.0"``) is stripped so the
+    emitted value stays spec-conformant across release-candidate cycles. The input is
+    returned unchanged if it does not start with a numeric ``major.minor.patch``.
+    """
+    match = _SEMVER_CORE_RE.match(version)
+    return f"{match.group(1)}.{match.group(2)}.{match.group(3)}" if match else version
+
+
+def _get_osi_library_version() -> str | None:
+    """Best-effort OSI interface (schema) version from the linked ``osi3`` library.
+
+    Used only as a fallback for ``min_osi_version`` / ``max_osi_version`` when no written
+    message carries an embedded ``InterfaceVersion``. Returns ``None`` if ``osi3`` is not
+    importable (the import is intentionally lazy so the writer does not hard-depend on it).
+    """
+    try:
+        from osi3 import osi_version_pb2
     except (ImportError, ModuleNotFoundError):
-        return "0.0.0"
+        logger.warning("osi3 is not importable; cannot determine a fallback OSI version for trace metadata")
+        return None
+    interface_version = osi_version_pb2.DESCRIPTOR.GetOptions().Extensions[osi_version_pb2.current_interface_version]
+    return f"{interface_version.version_major}.{interface_version.version_minor}.{interface_version.version_patch}"
+
+
+def _get_message_osi_version(message: Message) -> tuple[int, int, int] | None:
+    """Extract the embedded OSI ``InterfaceVersion`` from a top-level OSI message.
+
+    Returns ``(major, minor, patch)`` if the message has a populated ``version`` field,
+    otherwise ``None`` (the message type has no ``version`` field, it is unset, or it is
+    the meaningless all-zero default).
+    """
+    try:
+        if not message.HasField("version"):
+            return None
+    except ValueError:
+        return None
+    version = message.version
+    triple = (version.version_major, version.version_minor, version.version_patch)
+    return None if triple == (0, 0, 0) else triple
 
 
 def prepare_required_file_metadata() -> dict[str, str]:
     """Prepare the required 'net.asam.osi.trace' metadata with default values.
 
-    Returns a dict with required keys populated with placeholder/current values.
+    ``version`` is the OSI trace-file *format* version implemented by this library
+    (:data:`OSI_TRACE_FILE_SPEC_VERSION`, normalized to ``major.minor.patch``).
+    ``min_osi_version`` / ``max_osi_version`` are intentionally left empty here: when the
+    metadata is written by :class:`MultiTraceWriter`, they are filled from the embedded
+    ``InterfaceVersion`` of the messages actually written (falling back to the linked OSI
+    library version). Callers using an external writer may fill them in themselves.
     """
     return {
-        "version": _get_package_version(),
+        "version": _normalize_osi_version_string(OSI_TRACE_FILE_SPEC_VERSION),
         "min_osi_version": "",
         "max_osi_version": "",
         "min_protobuf_version": google.protobuf.__version__,
@@ -104,6 +149,11 @@ class MultiTraceWriter(TraceWriter):
         self._channel_metadata: dict[str, dict[str, str]] = {}
         self._schema_cache: dict[str, int] = {}  # schema_name -> schema_id
         self._written_count = 0
+        # The net.asam.osi.trace record is buffered at open() and written at close(),
+        # once the OSI schema version(s) of the written messages are known.
+        self._pending_file_metadata: dict[str, str] | None = None
+        self._osi_version_min: tuple[int, int, int] | None = None
+        self._osi_version_max: tuple[int, int, int] | None = None
 
     def open(  # type: ignore[override]
         self,
@@ -168,7 +218,11 @@ class MultiTraceWriter(TraceWriter):
 
             file_metadata = metadata if metadata is not None else prepare_required_file_metadata()
             _validate_file_metadata(file_metadata)
-            self._mcap_writer.add_metadata(name=OSI_TRACE_METADATA_NAME, data=file_metadata)
+            # Defer writing the net.asam.osi.trace record until close(): min/max_osi_version
+            # are filled from the embedded InterfaceVersion of the messages actually written.
+            self._pending_file_metadata = dict(file_metadata)
+            self._osi_version_min = None
+            self._osi_version_max = None
 
             self._written_count = 0
             return True
@@ -271,11 +325,48 @@ class MultiTraceWriter(TraceWriter):
                 data=data,
                 publish_time=log_time,
             )
+            self._track_osi_version(message)
             self._written_count += 1
             return True
         except (OSError, EncodeError, McapError) as e:
             logger.error("Failed to write message to topic '%s': %s", topic, e)
             return False
+
+    def _track_osi_version(self, message: Message) -> None:
+        """Update the running min/max embedded OSI ``InterfaceVersion`` from a message."""
+        version = _get_message_osi_version(message)
+        if version is None:
+            return
+        if self._osi_version_min is None or version < self._osi_version_min:
+            self._osi_version_min = version
+        if self._osi_version_max is None or version > self._osi_version_max:
+            self._osi_version_max = version
+
+    def _finalize_file_metadata(self) -> None:
+        """Write the buffered net.asam.osi.trace record, filling min/max_osi_version.
+
+        ``min_osi_version`` / ``max_osi_version`` are derived from the embedded
+        ``InterfaceVersion`` of the written messages, falling back to the linked OSI
+        library version when no message carried one. Non-empty user-provided values are
+        respected and never overwritten.
+        """
+        if self._mcap_writer is None or self._pending_file_metadata is None:
+            return
+        metadata = self._pending_file_metadata
+        min_str = "{}.{}.{}".format(*self._osi_version_min) if self._osi_version_min is not None else None
+        max_str = "{}.{}.{}".format(*self._osi_version_max) if self._osi_version_max is not None else None
+        if min_str is None or max_str is None:
+            fallback = _get_osi_library_version()
+            if fallback is not None:
+                min_str = min_str or fallback
+                max_str = max_str or fallback
+        # Only fill fields the caller left empty; respect explicit user values.
+        if not metadata.get("min_osi_version") and min_str:
+            metadata["min_osi_version"] = min_str
+        if not metadata.get("max_osi_version") and max_str:
+            metadata["max_osi_version"] = max_str
+        self._mcap_writer.add_metadata(name=OSI_TRACE_METADATA_NAME, data=metadata)
+        self._pending_file_metadata = None
 
     def add_file_metadata(self, name: str, data: dict[str, str]) -> bool:
         """Add additional file-level metadata.
@@ -296,6 +387,7 @@ class MultiTraceWriter(TraceWriter):
         """Finalize and close the MCAP file."""
         try:
             if self._mcap_writer is not None:
+                self._finalize_file_metadata()
                 self._mcap_writer.finish()
                 logger.info(
                     "Wrote %d messages to channels [%s] in '%s'",
@@ -314,6 +406,9 @@ class MultiTraceWriter(TraceWriter):
             self._active_channels.clear()
             self._channel_metadata.clear()
             self._schema_cache.clear()
+            self._pending_file_metadata = None
+            self._osi_version_min = None
+            self._osi_version_max = None
 
     @property
     def written_count(self) -> int:

--- a/python/osi_utilities/tracefile/writers/multi.py
+++ b/python/osi_utilities/tracefile/writers/multi.py
@@ -80,18 +80,30 @@ def _get_osi_library_version() -> str | None:
 def _get_message_osi_version(message: Message) -> tuple[int, int, int] | None:
     """Extract the embedded OSI ``InterfaceVersion`` from a top-level OSI message.
 
-    Returns ``(major, minor, patch)`` if the message has a populated ``version`` field,
-    otherwise ``None`` (the message type has no ``version`` field, it is unset, or it is
-    the meaningless all-zero default).
+    Returns ``(major, minor, patch)`` if the message carries a populated, OSI-shaped
+    ``version`` field, otherwise ``None`` (no ``version`` field, it is not a singular
+    ``InterfaceVersion`` submessage, it is unset, or it is the meaningless all-zero
+    default). Mirrors the C++ ``GetMessageOsiVersion`` guards so that writing a non-OSI
+    message that merely happens to carry a differently-shaped ``version`` field cannot
+    crash the writer.
     """
+    field = message.DESCRIPTOR.fields_by_name.get("version")
+    if field is None or field.is_repeated or field.message_type is None:
+        return None
     try:
         if not message.HasField("version"):
             return None
     except ValueError:
         return None
     version = message.version
-    triple = (version.version_major, version.version_minor, version.version_patch)
-    return None if triple == (0, 0, 0) else triple
+    components = (
+        getattr(version, "version_major", 0),
+        getattr(version, "version_minor", 0),
+        getattr(version, "version_patch", 0),
+    )
+    if not all(isinstance(component, int) for component in components):
+        return None
+    return None if components == (0, 0, 0) else components
 
 
 def prepare_required_file_metadata() -> dict[str, str]:

--- a/python/tests/test_extended.py
+++ b/python/tests/test_extended.py
@@ -941,3 +941,14 @@ class TestOsiTraceMetadataVersions:
         data = _read_osi_trace_metadata(path)
         assert data["min_osi_version"] == "3.0.0"
         assert data["max_osi_version"] == "3.0.0"
+
+    def test_user_supplied_version_is_normalized(self, tmp_dir: Path):
+        path = tmp_dir / "user_version.mcap"
+        meta = prepare_required_file_metadata()
+        # A caller-supplied pre-release version must be normalized to major.minor.patch.
+        meta["version"] = "3.8.0-rc1"
+        with MultiTraceWriter() as w:
+            w.open(path, meta)
+            w.write_message(_sv_with_version(3, 6, 1, index=1))
+        data = _read_osi_trace_metadata(path)
+        assert data["version"] == "3.8.0"

--- a/python/tests/test_extended.py
+++ b/python/tests/test_extended.py
@@ -8,6 +8,7 @@ Covers error paths, edge cases, and MCAPChannel — complementing test_tracefile
 
 from __future__ import annotations
 
+import re
 import struct
 import tempfile
 from pathlib import Path
@@ -36,9 +37,14 @@ from osi_utilities import (
     SingleTraceWriter,
 )
 from osi_utilities.timestamp import timestamp_to_nanoseconds
-from osi_utilities.tracefile._config import MAX_EXPECTED_MESSAGE_SIZE
+from osi_utilities.tracefile._config import MAX_EXPECTED_MESSAGE_SIZE, OSI_TRACE_FILE_SPEC_VERSION
 from osi_utilities.tracefile._mcap_utils import build_file_descriptor_set
-from osi_utilities.tracefile.writers.multi import prepare_required_file_metadata
+from osi_utilities.tracefile.writers.multi import (
+    _get_message_osi_version,
+    _get_osi_library_version,
+    _normalize_osi_version_string,
+    prepare_required_file_metadata,
+)
 
 # ===========================================================================
 # Fixtures
@@ -812,3 +818,100 @@ class TestMultiTypeRoundtrip:
             assert len(results) == 1
             assert results[0].message_type == msg_type
             assert results[0].message.timestamp.seconds == 77
+
+
+# ===========================================================================
+# net.asam.osi.trace metadata versioning (version / min_osi_version / max_osi_version)
+# ===========================================================================
+
+
+def _sv_with_version(major: int, minor: int, patch: int, index: int = 0) -> SensorView:
+    sv = SensorView()
+    sv.timestamp.seconds = index
+    sv.version.version_major = major
+    sv.version.version_minor = minor
+    sv.version.version_patch = patch
+    return sv
+
+
+def _read_osi_trace_metadata(path: Path) -> dict[str, str]:
+    with MultiTraceReader() as reader:
+        reader.open(path)
+        records = [m for m in reader.get_file_metadata() if m["name"] == "net.asam.osi.trace"]
+    assert len(records) == 1
+    return records[0]["data"]
+
+
+class TestOsiTraceMetadataVersions:
+    """`version` is the trace-file FORMAT version; min/max_osi_version come from the data."""
+
+    def test_prepare_metadata_version_is_spec_constant(self):
+        meta = prepare_required_file_metadata()
+        assert meta["version"] == _normalize_osi_version_string(OSI_TRACE_FILE_SPEC_VERSION)
+        assert re.fullmatch(r"\d+\.\d+\.\d+", meta["version"])
+        # min/max are placeholders until finalized at close()
+        assert meta["min_osi_version"] == ""
+        assert meta["max_osi_version"] == ""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("3.8.0", "3.8.0"),
+            ("3.8.0-rc1", "3.8.0"),
+            ("3.9.0-alpha.2+build.7", "3.9.0"),
+            ("  3.8.0-rc1 ", "3.8.0"),
+            ("10.20.30", "10.20.30"),
+            ("not-a-version", "not-a-version"),
+        ],
+    )
+    def test_normalize_version_string(self, raw: str, expected: str):
+        assert _normalize_osi_version_string(raw) == expected
+
+    def test_get_message_osi_version(self):
+        assert _get_message_osi_version(_sv_with_version(3, 6, 1)) == (3, 6, 1)
+        # all-zero (set but meaningless) and unset both yield None
+        zero = SensorView()
+        zero.version.version_major = 0  # marks the submessage present but 0.0.0
+        assert _get_message_osi_version(zero) is None
+        assert _get_message_osi_version(_make_ground_truth()) is None
+
+    def test_min_max_from_written_messages(self, tmp_dir: Path):
+        path = tmp_dir / "versions.mcap"
+        with MultiTraceWriter() as w:
+            w.open(path)
+            w.add_channel("/sv", SensorView)
+            w.add_channel("/gt", GroundTruth)
+            w.write_message(_sv_with_version(3, 5, 2, index=1), "/sv")
+            gt = GroundTruth()
+            gt.timestamp.seconds = 2
+            gt.version.version_major, gt.version.version_minor, gt.version.version_patch = 3, 7, 0
+            w.write_message(gt, "/gt")
+            # message without a version must not influence min/max
+            w.write_message(_make_ground_truth(3), "/gt")
+        data = _read_osi_trace_metadata(path)
+        assert data["version"] == _normalize_osi_version_string(OSI_TRACE_FILE_SPEC_VERSION)
+        assert data["min_osi_version"] == "3.5.2"
+        assert data["max_osi_version"] == "3.7.0"
+
+    def test_unset_version_falls_back_to_library(self, tmp_dir: Path):
+        path = tmp_dir / "fallback.mcap"
+        with MultiTraceWriter() as w:
+            w.open(path)
+            w.write_message(_make_ground_truth(1))  # no embedded version
+        data = _read_osi_trace_metadata(path)
+        library_version = _get_osi_library_version()
+        assert library_version is not None
+        assert data["min_osi_version"] == library_version
+        assert data["max_osi_version"] == library_version
+
+    def test_user_supplied_min_max_preserved(self, tmp_dir: Path):
+        path = tmp_dir / "user_meta.mcap"
+        meta = prepare_required_file_metadata()
+        meta["min_osi_version"] = "3.0.0"
+        meta["max_osi_version"] = "3.0.0"
+        with MultiTraceWriter() as w:
+            w.open(path, meta)
+            w.write_message(_sv_with_version(3, 6, 1, index=1))
+        data = _read_osi_trace_metadata(path)
+        assert data["min_osi_version"] == "3.0.0"
+        assert data["max_osi_version"] == "3.0.0"

--- a/python/tests/test_extended.py
+++ b/python/tests/test_extended.py
@@ -875,6 +875,32 @@ class TestOsiTraceMetadataVersions:
         assert _get_message_osi_version(zero) is None
         assert _get_message_osi_version(_make_ground_truth()) is None
 
+    def test_get_message_osi_version_non_osi_scalar_field_does_not_raise(self):
+        # A non-OSI message whose ``version`` field is a plain scalar (not an
+        # InterfaceVersion submessage) must be ignored gracefully, mirroring the C++
+        # GetMessageOsiVersion guard, rather than crashing with AttributeError.
+        from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
+
+        file_proto = descriptor_pb2.FileDescriptorProto()
+        file_proto.name = "scalar_version_regression.proto"
+        file_proto.syntax = "proto2"
+        file_proto.package = "osiutilstest"
+        msg_proto = file_proto.message_type.add()
+        msg_proto.name = "ScalarVersionMsg"
+        field_proto = msg_proto.field.add()
+        field_proto.name = "version"
+        field_proto.number = 1
+        field_proto.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+        field_proto.type = descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
+
+        pool = descriptor_pool.DescriptorPool()
+        file_descriptor = pool.Add(file_proto)
+        message_class = message_factory.GetMessageClass(file_descriptor.message_types_by_name["ScalarVersionMsg"])
+        scalar_message = message_class()
+        scalar_message.version = 5
+
+        assert _get_message_osi_version(scalar_message) is None
+
     def test_min_max_from_written_messages(self, tmp_dir: Path):
         path = tmp_dir / "versions.mcap"
         with MultiTraceWriter() as w:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2026, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
SPDX-License-Identifier: MPL-2.0
-->

## Related Issue

refs #51

## Summary

Corrects the `net.asam.osi.trace` MCAP metadata version fields in both the Python and C++
bindings, and bumps the implemented OSI trace-file format version to the released **3.8.0**.

### Background: three independent version concepts

Per the ASAM OSI trace-file specification
(`submodules/osi-cpp/open-simulation-interface/doc/architecture/trace_file_formats.adoc`),
the mandatory `net.asam.osi.trace` record carries three *distinct* version concepts, each
sourced differently:

| Field | Meaning | Source |
| --- | --- | --- |
| `version` | OSI trace-file **format** version the file conforms to | fixed `OSI_TRACE_FILE_SPEC_VERSION` constant, normalized to `major.minor.patch` |
| `min_osi_version` / `max_osi_version` | OSI **schema** version(s) of the data in the channels | embedded `InterfaceVersion` of the messages actually written |
| `min_protobuf_version` / `max_protobuf_version` | protobuf runtime | linked protobuf |

The spec is explicit that `version` "is not necessarily the same as the OSI schema version(s)
used in the trace file ... it indicates the version of the OSI trace file format itself,"
whereas `min/max_osi_version` are "the minimum/maximum version of the OSI schema used in the
trace file OSI channels." Because the writers only *repack* messages (preserving each
message's embedded `InterfaceVersion`), the schema version must be sourced from the messages
actually written, not from the linked library.

### What was wrong

- **Python** wrote the *package* version (e.g. `0.4.0`) into `version` and left
  `min/max_osi_version` empty — both incorrect.
- **C++** wrote the format version into `version` (correct) but derived `min/max_osi_version`
  from the *linked OSI library* version, so a file containing 3.5.x data produced by a
  3.8.0-linked build was mislabeled as 3.8.0.

### What this PR does

**Data-accurate metadata lifecycle (both bindings).** The `net.asam.osi.trace` record is now
*buffered* and *finalized at `Close()` / `close()`* instead of being written up front:

- `version` is set to the normalized `OSI_TRACE_FILE_SPEC_VERSION`.
- As each message is written, its embedded `InterfaceVersion` updates a running min/max.
- At close, `min_osi_version` / `max_osi_version` are filled from those running values,
  **falling back** to the linked OSI library version when no written message carried one, and
  **never overwriting** values the caller supplied explicitly.

**Format-version normalization.** The emitted `version` is normalized to a strict
`major.minor.patch` core, stripping any pre-release/build suffix (e.g. `3.8.0-rc1` -> `3.8.0`,
`3.9.0-alpha.2+build.7` -> `3.9.0`). This keeps the field spec-conformant across
release-candidate cycles without code changes. It is applied both to the default constant and
to any caller-supplied `version` (via `AddFileMetadata` in C++ / `open()` in Python), so the
two entry points cannot diverge.

**OSI 3.8.0 bump.** `OSI_TRACE_FILE_SPEC_VERSION` `3.8.0-rc1` -> `3.8.0`. No submodule bump is
needed: the pinned OSI definitions (`submodules/osi-cpp/open-simulation-interface`, commit
`083481d`) already report `VERSION = 3.8.0`; only the constant carried the `-rc1` suffix. The
C++ (`CMakeLists.txt`) and Python (`python/osi_utilities/tracefile/_config.py`) constants are
documented as a pair that must be kept in sync (see `doc/releasing.md`).

### Robustness and correctness details

- **Buffer only after a successful write (C++).** Metadata buffering happens *after* the
  channel write succeeds. A failed write therefore no longer reserves the record, no longer
  blocks a later explicit `AddFileMetadata("net.asam.osi.trace", ...)`, and no longer causes
  `Close()` to emit fallback `min/max` for a file with zero successfully written messages.
- **Numeric version comparison.** min/max use `tuple` / `std::array<uint32_t, 3>` comparison,
  so `3.10.0 > 3.9.0` holds (a naive lexicographic string compare would get this wrong).
- **All-zero versions are ignored.** OSI documents an all-zero `InterfaceVersion` as
  unset/legacy; such messages do not influence min/max and trigger the library-version
  fallback instead.
- **Non-OSI messages cannot crash the writer.** Extracting the embedded version is guarded by
  the field shape (a singular `InterfaceVersion` submessage with integer components), mirrored
  across C++ (`GetMessageOsiVersion`) and Python (`_get_message_osi_version`). A non-OSI
  message that merely happens to carry a differently-shaped `version` field is ignored
  gracefully instead of raising.
- **Lazy `osi3` fallback (Python).** The fallback library-version lookup imports `osi3`
  lazily and guarded, so the writer does not gain a hard dependency on it.

### Documentation

- `doc/overview.md` clarifies that `version` is the trace-file *format* version (not the data
  schema version) and that `min/max_osi_version` are auto-derived from the written messages.
- `doc/releasing.md` documents the C++/Python `OSI_TRACE_FILE_SPEC_VERSION` sync requirement.

## Validation

- **Python** (venv with `osi3` 3.8.0 from `submodules/osi-python`):
  - `pytest tests/` -> **223 passed**. The metadata-version suite (13 cases) covers the
    format-version constant, normalization (incl. suffix stripping and non-numeric
    passthrough), data-accurate min/max from written messages, the library-version fallback,
    user-supplied min/max preservation, caller-supplied `version` normalization, and the
    non-OSI scalar-`version` guard (regression against an `AttributeError` crash).
  - `ruff check` and `ruff format --check` -> clean.
- **C++**:
  - GoogleTest cases added (7) for data-accurate `min/max_osi_version`, the library-version
    fallback, user-value preservation, format-version normalization (default and explicit),
    suffix stripping, and the "failed write does not reserve metadata" contract.
  - `clang-format` (project style) is clean on the changed files; changed/new lines are within
    the 180-column limit. The pure normalization logic was validated in isolation with
    `g++ -std=c++17`.
  - The full vcpkg build + `ctest` rely on CI (no local MSVC/vcpkg toolchain in this
    environment) -- see the CI checks on this PR.

## Checklist

- [x] Unit tests added/updated for behavior changes.
- [x] Documentation updated for user-visible/API changes (`doc/overview.md`, `doc/releasing.md`).
- [x] Local checks pass (`pre-commit` format/lint; Python build + tests fully local; C++
      build + tests via CI -- see Validation).
- [x] Reviewer(s) assigned.
